### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Here's how to process the Set-Cookie header(s) on a node HTTP/HTTPS response:
 
 ``` javascript
 if (res.headers['set-cookie'] instanceof Array)
-  cookies = res.headers['set-cookie'].map(Cookie.parse);
+  cookies = res.headers['set-cookie'].map(function (c) { return (Cookie.parse(c)); });
 else
   cookies = [Cookie.parse(res.headers['set-cookie'])];
 ```


### PR DESCRIPTION
Correct argument semantics issue with sample code for Cookie.parse (use of Array map() with Cookie.parse).

In the sample code for Cookie.parse (at https://github.com/goinstant/node-cookie#cookieparseheaderstrictfalse), this function is passed directly to Array map(), in the line:

``` javascript
cookies = res.headers['set-cookie'].map(Cookie.parse);
```

However, map() expects the signature of the provided function to include a numeric value representing the index of the array element being processed as the second argument, but Cookie.parse()'s second argument is "strict", a boolean. Invoked in this way, this has the effect of calling parse with strict=false for the first 'set-cookie', and with strict=true for all the others.

This line of the sample could instead be something like:

``` javascript
cookies = res.headers['set-cookie'].map(function (c)
  {
    return (Cookie.parse(c));
  });
```
