### PR TITLE
CookieJar.deserialize does not modify its input

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1212,6 +1212,7 @@ CookieJar.prototype._importCookies = function(serialized, cb) {
   if (!cookies || !Array.isArray(cookies)) {
     return cb(new Error('serialized jar has no cookies array'));
   }
+  cookies = cookies.slice(); // do not modify the original
 
   function putNext(err) {
     if (err) {

--- a/test/jar_serialization_test.js
+++ b/test/jar_serialization_test.js
@@ -235,7 +235,15 @@ vows
             return CookieJar.deserializeSync(data);
           },
           "memstores are identical": function(newJar) {
-            assert.deepEqual(this.jar.store, newJar.store);
+            assert.deepEqual(newJar.store, this.jar.store);
+          }
+        },
+        "then deserialize again": {
+          topic: function(data) {
+            return CookieJar.deserializeSync(data);
+          },
+          "memstores are still identical": function(newJar) {
+            assert.deepEqual(newJar.store, this.jar.store);
           }
         }
       },


### PR DESCRIPTION
Fix #59

Switched the order of `deepEqual` arguments to match its interface and improve readability of error messages
`assert.deepEqual(actual, expected[, message])`