### PR TITLE
Explicit punycode dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
 - stable
+- "7.0"
 - "6.0"
 - "5.12"
 - "5.0"

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "async": "^1.4.2",
     "string.prototype.repeat": "^0.2.0",
     "vows": "^0.8.1"
+  },
+  "dependencies": {
+    "punycode": "^1.4.1"
   }
 }


### PR DESCRIPTION
Node v7 soft-deprecates the punycode module.

See https://nodejs.org/en/blog/release/v7.0.0/ and
https://github.com/nodejs/node/pull/7941