### PR TITLE
permutePath now returns paths with slash on the end

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -575,6 +575,9 @@ function permutePath(path) {
       break;
     }
     path = path.substr(0,lindex);
+    // sometimes sites can send something like "Set-Cookie: name=value; path=/somefolder/"
+    // so we need indexing for both "/somefolder/" and "/somefolder"
+    permutations.push(path + '/');
     permutations.push(path);
   }
   permutations.push('/');


### PR DESCRIPTION
Sometimes sites can send something like "Set-Cookie: name=value; path=/somefolder/".
So we need indexing for both "/somefolder/" and "/somefolder".