### PR TITLE
fix: ReDoS in cookie pair regexp

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -58,7 +58,7 @@ var CONTROL_CHARS = /[\x00-\x1F]/;
 // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L60)
 // '=' and ';' are attribute/values separators
 // (see: https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/parsed_cookie.cc#L64)
-var COOKIE_PAIR = /^(([^=;]+))\s*=\s*([^\n\r\0]*)/;
+var COOKIE_PAIR = /^(([^=;]+))\s{0,512}=\s*([^\n\r\0]*)/;
 
 // Used to parse non-RFC-compliant cookies like '=abc' when given the `loose`
 // option in Cookie.parse:


### PR DESCRIPTION
Limiting whitespaces to 512. While the RFC does not specify a limit on number of whitespace in key, it's unreasonable to have thousands of them.