### PR TITLE
Added NYC coverge and reporting to tough-cookie.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 .*.sw[nmop]
 npm-debug.log
 docker-compose.override.yml
+.nyc_output
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 docker-compose.yml
 Dockerfile
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -58,13 +58,15 @@
   ],
   "scripts": {
     "suffixup": "curl -o public_suffix_list.dat https://publicsuffix.org/list/public_suffix_list.dat && ./generate-pubsuffix.js",
-    "test": "vows test/*_test.js"
+    "test": "vows test/*_test.js",
+    "cover": "nyc --reporter=lcov --reporter=html vows test/*_test.js"
   },
   "engines": {
     "node": ">=0.8"
   },
   "devDependencies": {
     "async": "^1.4.2",
+    "nyc": "^11.6.0",
     "string.prototype.repeat": "^0.2.0",
     "vows": "^0.8.1"
   },


### PR DESCRIPTION
Pulled in NYC (Istanbul 2.0) into our package.json. Did a few runs with the local package, set it up to do html based coverage reporting (through vows).