### PR TITLE
Fix assert throws assertion

### DIFF
--- a/test/jar_serialization_test.js
+++ b/test/jar_serialization_test.js
@@ -185,7 +185,7 @@ vows
       "Cannot call toJSON": function(jar) {
         assert.throws(function() {
           jar.toJSON();
-        }, 'getAllCookies is not implemented (therefore jar cannot be serialized)');
+        }, /^Error: getAllCookies is not implemented \(therefore jar cannot be serialized\)$/);
       }
     }
   })
@@ -200,7 +200,7 @@ vows
       "Cannot call toJSON": function(jar) {
         assert.throws(function() {
           jar.toJSON();
-        }, 'CookieJar store is not synchronous; use async API instead.');
+        }, /^Error: CookieJar store is not synchronous; use async API instead\.$/);
       }
     }
   })


### PR DESCRIPTION
So far the error message was not tested when calling `assert.throws`.
In new Node.js versions it is warned in case this is detected.
Now the error message is validated by using a regular expression
instead of the string.