### PR TITLE
Fix custom inspection

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -31,6 +31,7 @@
 'use strict';
 var net = require('net');
 var urlParse = require('url').parse;
+var util = require('util');
 var pubsuffix = require('./pubsuffix-psl');
 var Store = require('./store').Store;
 var MemoryCookieStore = require('./memstore').MemoryCookieStore;
@@ -755,6 +756,12 @@ Cookie.prototype.inspect = function inspect() {
     '; cAge='+(this.creation ? (now-this.creation.getTime())+'ms' : '?') +
     '"';
 };
+
+// Use the new custom inspection symbol to add the custom inspect function if
+// available.
+if (util.inspect.custom) {
+  Cookie.prototype[util.inspect.custom] = Cookie.prototype.inspect;
+}
 
 Cookie.prototype.toJSON = function() {
   var obj = {};

--- a/lib/memstore.js
+++ b/lib/memstore.js
@@ -50,6 +50,12 @@ MemoryCookieStore.prototype.inspect = function() {
   return "{ idx: "+util.inspect(this.idx, false, 2)+' }';
 };
 
+// Use the new custom inspection symbol to add the custom inspect function if
+// available.
+if (util.inspect.custom) {
+  MemoryCookieStore.prototype[util.inspect.custom] = MemoryCookieStore.prototype.inspect;
+}
+
 MemoryCookieStore.prototype.findCookie = function(domain, path, key, cb) {
   if (!this.idx[domain]) {
     return cb(null,undefined);


### PR DESCRIPTION
From Node.js 11 on custom inspection will not work with the `inspect`
property anymore. This changes it to use the newer custom inspection
symbol if available. To stay backwarts compatible it keeps the old
function in place in case it is called directly by users.