### PR TITLE
Fix jar clone and cloneSync methods

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1371,7 +1371,6 @@ CookieJar.deserializeSync = function(strOrObj, store) {
 };
 CookieJar.fromJSON = CookieJar.deserializeSync;
 
-CAN_BE_SYNC.push('clone');
 CookieJar.prototype.clone = function(newStore, cb) {
   if (arguments.length === 1) {
     cb = newStore;
@@ -1382,8 +1381,16 @@ CookieJar.prototype.clone = function(newStore, cb) {
     if (err) {
       return cb(err);
     }
-    CookieJar.deserialize(newStore, serialized, cb);
+    CookieJar.deserialize(serialized, newStore, cb);
   });
+};
+
+CookieJar.prototype._cloneSync = syncWrap('clone');
+CookieJar.prototype.cloneSync = function(newStore) {
+  if (!newStore.synchronous) {
+    throw new Error('CookieJar clone destination store is not synchronous; use async API instead.');
+  }
+  return this._cloneSync(newStore);
 };
 
 // Use a closure to provide a true imperative API for synchronous stores.


### PR DESCRIPTION
Fixes #101 and makes it so that the `.cloneSync` method does what the documentation says (i.e., it checks for the new store to be synchronous too!)