### PR TITLE
Purposefully don't lock dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 docker-compose.override.yml
 .nyc_output
 coverage
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ docker-compose.yml
 Dockerfile
 .nyc_output
 coverage
+package-lock.json


### PR DESCRIPTION
Since this is a module and not an end package, we want CI/etc. to always upgrade packages based on semver.