### PR TITLE
PROPOSAL: add warning message when decodeURI fails

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -681,7 +681,7 @@ function getCookieContext(url) {
     url = decodeURI(url);
   }
   catch(err) {
-    // Silently swallow error
+    console.log('WARNING: could not decode URI for tough-cookie');
   }
 
   return urlParse(url);


### PR DESCRIPTION
Hey folks,

Love what you've done on `tough-cookie`! I was having a bit of trouble debugging an issue today, and as it turned out, the format of the domain passed in wasn't one that `decodeURI` can parse. No big deal. However, I was unaware that this was the cause until I dug into the source a bit. 

I found this `catch`. I'm sure you have your reasons to swallow the error. I tried to guess what that might be and ensured that the message I included didn't disclose anything harmful in - say - production :D 

Also, I saw this just above: 
> NOTE: decodeURI will throw on malformed URIs (see GH-32). Therefore, we will just skip decoding for such URIs.

Makes perfect sense. In my uninformed opinion, I couldn't see anything wrong with still logging something to console.

Do with this what you will, but it would be absolutely legit to hear why this error gets swallowed if this proposal is indeed a silly one.

And as always,

![Use the force](https://media.giphy.com/media/l1AsVTpwWUgCvnR2U/giphy.gif)