### PR TITLE
Use ip-regex instead of net.isIP. Fix #125

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -29,9 +29,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict';
-var net = require('net');
 var urlParse = require('url').parse;
 var util = require('util');
+var ipRegex = require('ip-regex')({ exact: true });
 var pubsuffix = require('./pubsuffix-psl');
 var Store = require('./store').Store;
 var MemoryCookieStore = require('./memstore').MemoryCookieStore;
@@ -320,7 +320,7 @@ function domainMatch(str, domStr, canonicalize) {
   /* "All of the following [three] conditions hold:" (order adjusted from the RFC) */
 
   /* "* The string is a host name (i.e., not an IP address)." */
-  if (net.isIP(str)) {
+  if (ipRegex.test(str)) {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "vows": "^0.8.2"
   },
   "dependencies": {
+    "ip-regex": "^3.0.0",
     "psl": "^1.1.28",
     "punycode": "^2.1.1"
   }


### PR DESCRIPTION
Replace [net.isIP] with [ip-regex].

[ip-regex]: https://github.com/sindresorhus/ip-regex/blob/master/index.js
[net.isIP]: https://github.com/nodejs/node/blob/master/lib/internal/net.js#L7