### PR TITLE
setCookie arg must be Cookie or string

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1007,11 +1007,15 @@ CookieJar.prototype.setCookie = function(cookie, url, options, cb) {
   }
 
   // S5.3 step 1
-  if (!(cookie instanceof Cookie)) {
+  if (typeof(cookie) === 'string' || cookie instanceof String) {
     cookie = Cookie.parse(cookie, { loose: loose });
+    if (!cookie) {
+      err = new Error("Cookie failed to parse");
+      return cb(options.ignoreError ? null : err);
+    }
   }
-  if (!cookie) {
-    err = new Error("Cookie failed to parse");
+  else if (!(cookie instanceof Cookie)) {
+    err = new Error("First argument to setCookie must be a Cookie object or string");
     return cb(options.ignoreError ? null : err);
   }
 

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1015,6 +1015,8 @@ CookieJar.prototype.setCookie = function(cookie, url, options, cb) {
     }
   }
   else if (!(cookie instanceof Cookie)) {
+    // If you're seeing this error, and are passing in a Cookie object, 
+    // it *might* be a Cookie object from another loaded version of tough-cookie.
     err = new Error("First argument to setCookie must be a Cookie object or string");
     return cb(options.ignoreError ? null : err);
   }

--- a/test/cookie_jar_test.js
+++ b/test/cookie_jar_test.js
@@ -541,4 +541,31 @@ vows
       }
     }
   })
+  .addBatch({
+    "Issue 132 - setCookie": {
+      "with foreign object": {
+        topic: function() {
+          var jar = new CookieJar();
+          jar.setCookie({key:"x",value:"y"}, "http://example.com/", this.callback);
+        },
+        "results in an error": function(err, cookie) {
+          assert(err != null);
+          assert(!cookie);
+          assert.equal(err.message, "First argument to setCookie must be a Cookie object or string");
+        },
+      },
+      "with String instance": {
+        topic: function() {
+          var jar = new CookieJar();
+          jar.setCookie(new String("x=y; Domain=example.com; Path=/"), "http://example.com/", this.callback);
+        },
+        "is fine": function(err, cookie) {
+          assert(!err);
+          assert(!!cookie);
+          assert.instanceOf(cookie, Cookie);
+          assert.equal(cookie.key, "x");
+        },
+      }
+    }
+  })
   .export(module);


### PR DESCRIPTION
Addresses #132, partially. The error message is clearer, indicating that
this method only accepts the afformentioned types. The part of 132 that
it doesn't address is the whole "Cookie instance from another version of
the `tough-cookie` package" thing, which isn't really solvable unless we
somehow expose the Cookie class that "belongs to" this CookieJar class,
which is maybe another patch.