### PR TITLE
Issue 125

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,5 @@ node_js:
 - "v10.*"
 - "v8.*"
 - "v6.*"
-- "v4.*"
-- "v0.12.*"
-- "v0.10.*"
 matrix:
   fast_finish: true

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -29,9 +29,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict';
-var net = require('net');
 var urlParse = require('url').parse;
 var util = require('util');
+var ipRegex = require('ip-regex')({ exact: true });
 var pubsuffix = require('./pubsuffix-psl');
 var Store = require('./store').Store;
 var MemoryCookieStore = require('./memstore').MemoryCookieStore;
@@ -320,7 +320,7 @@ function domainMatch(str, domStr, canonicalize) {
   /* "All of the following [three] conditions hold:" (order adjusted from the RFC) */
 
   /* "* The string is a host name (i.e., not an IP address)." */
-  if (net.isIP(str)) {
+  if (ipRegex.test(str)) {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "vows": "^0.8.2"
   },
   "dependencies": {
+    "ip-regex": "^3.0.0",
     "psl": "^1.1.28",
     "punycode": "^2.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "cover": "nyc --reporter=lcov --reporter=html vows test/*_test.js"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=6"
   },
   "devDependencies": {
     "async": "^1.4.2",


### PR DESCRIPTION
Fixes #125 - Upgrades minimum supported node.js version to v6 because (a) `ip-regexp` doesn't work before v4 and (b) `request` now requires v6+