### PR TITLE
Embed IP address regex and thoroughly test

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -31,7 +31,6 @@
 'use strict';
 var urlParse = require('url').parse;
 var util = require('util');
-var ipRegex = require('ip-regex')({ exact: true });
 var pubsuffix = require('./pubsuffix-psl');
 var Store = require('./store').Store;
 var MemoryCookieStore = require('./memstore').MemoryCookieStore;
@@ -77,6 +76,12 @@ var NUM_TO_DAY = [
 
 var MAX_TIME = 2147483647000; // 31-bit max
 var MIN_TIME = 0; // 31-bit min
+
+// Dumped from ip-regex@4.0.0, with the following changes:
+// * all capturing groups converted to non-capturing -- "(?:)"
+// * support for IPv6 Scoped Literal ("%eth1") removed
+// * lowercase hexadecimal only
+var IP_REGEX_LOWERCASE =/(?:^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$)|(?:^(?:(?:[a-f\d]{1,4}:){7}(?:[a-f\d]{1,4}|:)|(?:[a-f\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-f\d]{1,4}|:)|(?:[a-f\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,2}|:)|(?:[a-f\d]{1,4}:){4}(?:(?::[a-f\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,3}|:)|(?:[a-f\d]{1,4}:){3}(?:(?::[a-f\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,4}|:)|(?:[a-f\d]{1,4}:){2}(?:(?::[a-f\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,5}|:)|(?:[a-f\d]{1,4}:){1}(?:(?::[a-f\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,6}|:)|(?::(?:(?::[a-f\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,7}|:)))$)/;
 
 /*
  * Parses a Natural number (i.e., non-negative integer) with either the
@@ -309,7 +314,11 @@ function domainMatch(str, domStr, canonicalize) {
   }
 
   /*
-   * "The domain string and the string are identical. (Note that both the
+   * S5.1.3:
+   * "A string domain-matches a given domain string if at least one of the
+   * following conditions hold:"
+   *
+   * " o The domain string and the string are identical. (Note that both the
    * domain string and the string will have been canonicalized to lower case at
    * this point)"
    */
@@ -317,29 +326,31 @@ function domainMatch(str, domStr, canonicalize) {
     return true;
   }
 
-  /* "All of the following [three] conditions hold:" (order adjusted from the RFC) */
+  /* " o All of the following [three] conditions hold:" */
 
-  /* "* The string is a host name (i.e., not an IP address)." */
-  if (ipRegex.test(str)) {
-    return false;
-  }
-
-  /* "* The domain string is a suffix of the string" */
+  /* "  * The domain string is a suffix of the string" */
+  // first, check if substring:
   var idx = str.indexOf(domStr);
   if (idx <= 0) {
     return false; // it's a non-match (-1) or prefix (0)
   }
 
-  // e.g "a.b.c".indexOf("b.c") === 2
+  // next, check it's a proper suffix
+  // e.g., "a.b.c".indexOf("b.c") === 2
   // 5 === 3+2
-  if (str.length !== domStr.length + idx) { // it's not a suffix
-    return false;
+  if (str.length !== domStr.length + idx) {
+    return false; // it's not a suffix
   }
 
-  /* "* The last character of the string that is not included in the domain
-  * string is a %x2E (".") character." */
+  /* "  * The last character of the string that is not included in the
+   * domain string is a %x2E (".") character." */
   if (str.substr(idx-1,1) !== '.') {
-    return false;
+    return false; // doesn't align on "."
+  }
+
+  /* "  * The string is a host name (i.e., not an IP address)." */
+  if (IP_REGEX_LOWERCASE.test(str)) {
+    return false; // it's an IP address
   }
 
   return true;
@@ -1015,7 +1026,7 @@ CookieJar.prototype.setCookie = function(cookie, url, options, cb) {
     }
   }
   else if (!(cookie instanceof Cookie)) {
-    // If you're seeing this error, and are passing in a Cookie object, 
+    // If you're seeing this error, and are passing in a Cookie object,
     // it *might* be a Cookie object from another loaded version of tough-cookie.
     err = new Error("First argument to setCookie must be a Cookie object or string");
     return cb(options.ignoreError ? null : err);

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "vows": "^0.8.2"
   },
   "dependencies": {
-    "ip-regex": "^2.1.0",
     "psl": "^1.1.28",
     "punycode": "^2.1.1"
   }


### PR DESCRIPTION
Removes the dependency on `ip-regex` and adds test coverage on how exactly tough-cookie is treating IP addresses.