### PR TITLE
fix(cookie-jar): use typeof for checking type of option

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -995,7 +995,7 @@ CAN_BE_SYNC.push('setCookie');
 CookieJar.prototype.setCookie = function(cookie, url, options, cb) {
   var err;
   var context = getCookieContext(url);
-  if (options instanceof Function) {
+  if (typeof(options) === 'function' || options instanceof Function) {
     cb = options;
     options = {};
   }


### PR DESCRIPTION
Works around https://github.com/facebook/jest/issues/2549 when used in Jest