### PR TITLE
Use typeof for checking type of option

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1071,7 +1071,7 @@ class CookieJar {
   setCookie(cookie, url, options, cb) {
     let err;
     const context = getCookieContext(url);
-    if (options instanceof Function) {
+    if (typeof options === "function") {
       cb = options;
       options = {};
     }
@@ -1243,7 +1243,7 @@ class CookieJar {
   // RFC6365 S5.4
   getCookies(url, options, cb) {
     const context = getCookieContext(url);
-    if (options instanceof Function) {
+    if (typeof options === "function") {
       cb = options;
       options = {};
     }

--- a/test/regression_test.js
+++ b/test/regression_test.js
@@ -144,4 +144,48 @@ vows
       }
     }
   })
+  .addBatch({
+    "setCookie (without options) callback works even if it's not instanceof Function (GH-158/GH-175)": {
+      topic: function() {
+        const cj = new CookieJar();
+
+        const thisCallback = this.callback;
+        const cb = function(err, cookie) {
+          thisCallback(err, cookie);
+        };
+        Object.setPrototypeOf(cb, null);
+        assert(
+          !(cb instanceof Function),
+          "clearing callback prototype chain failed"
+        );
+
+        cj.setCookie("a=b", "http://example.com/index.html", cb);
+      },
+      works: function(c) {
+        assert.instanceOf(c, Cookie);
+      }
+    },
+    "getCookies (without options) callback works even if it's not instanceof Function (GH-175)": {
+      topic: function() {
+        const cj = new CookieJar();
+        const url = "http://example.com/index.html";
+        cj.setCookieSync("a=b", url);
+
+        const thisCallback = this.callback;
+        const cb = function(err, cookies) {
+          thisCallback(err, cookies);
+        };
+        Object.setPrototypeOf(cb, null);
+        assert(
+          !(cb instanceof Function),
+          "clearing callback prototype chain failed"
+        );
+
+        cj.getCookies(url, cb);
+      },
+      works: function(cookies) {
+        assert.lengthOf(cookies, 1);
+      }
+    }
+  })
   .export(module);


### PR DESCRIPTION
Fixes #175, related to #158 

Functions that are not "instanceof Function" can occur in e.g. Jest tests,
see https://github.com/facebook/jest/issues/2549

This was fixed once before (d94532d), now adding also regression tests
(and fixing same issue in getCookies, too).