### PR TITLE
Returned null in case of empty cookie value

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1081,6 +1081,9 @@ class CookieJar {
     if (typeof options === "function") {
       cb = options;
       options = {};
+
+      if(typeof cookie === 'string' && cookie.length <= 0 )
+        return cb(null);
     }
 
     const host = canonicalDomain(context.hostname);

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1099,10 +1099,12 @@ class CookieJar {
     if (validators.isFunction(options)) {
       cb = options;
       options = {};
-
-      if(!validators.isNonEmptyString(cookie))
-        return cb(null);
     }
+
+    if(!validators.isNonEmptyString(cookie) && !validators.isObject(cookie)) {
+      return cb(null);
+    }
+
     validators.validate(validators.isFunction(cb), cb);
 
     const host = canonicalDomain(context.hostname);

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1100,7 +1100,7 @@ class CookieJar {
       cb = options;
       options = {};
 
-      if(typeof cookie === 'string' && cookie.length <= 0 )
+      if(!validators.isNonEmptyString(cookie))
         return cb(null);
     }
     validators.validate(validators.isFunction(cb), cb);

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1101,11 +1101,11 @@ class CookieJar {
       options = {};
     }
 
-    if(!validators.isNonEmptyString(cookie) && !validators.isObject(cookie)) {
+    validators.validate(validators.isFunction(cb), cb);
+
+    if(!validators.isNonEmptyString(cookie) && !validators.isObject(cookie) && ( cookie instanceof String && cookie.length == 0)) {
       return cb(null);
     }
-
-    validators.validate(validators.isFunction(cb), cb);
 
     const host = canonicalDomain(context.hostname);
     const loose = options.loose || this.enableLooseMode;

--- a/test/cookie_jar_test.js
+++ b/test/cookie_jar_test.js
@@ -686,4 +686,21 @@ vows
       }
     }
   })
+  .addBatch({
+    "Issue #197 - CookieJar().setCookie crashes when empty cookie is passed": {
+      "with missing parameters": {
+        topic: function() {
+          const jar = new tough.CookieJar();
+          jar.setCookie(
+            '',
+            "https://google.com",
+            this.callback
+          );
+        },
+        "results in a error being returned because of missing parameters": function(err, cookies) {
+          assert(cookies == undefined);
+        }
+      }
+    }
+  })
   .export(module);


### PR DESCRIPTION
1. some of the old sites by mistake send a blank cookie, and whenever a blank cookie is encountered, failed to parse cookie error comes up - so I made a fix of checking the length and accordingly calling callback with null value.

Note: Either this fix, or CookieJar constructor needs to take SetCookieOptions too, as ignoreError is part of SetCookieOptions interface