### PR TITLE
Add explanation and more special-use domains

### DIFF
--- a/lib/permuteDomain.js
+++ b/lib/permuteDomain.js
@@ -33,15 +33,27 @@ const pubsuffix = require("./pubsuffix-psl");
 
 // Gives the permutation of all possible domainMatch()es of a given domain. The
 // array is in shortest-to-longest order.  Handy for indexing.
-const SPECIAL_USE_DOMAINS = ["local"]; // RFC 6761
+
+// RFC 6761
+const SPECIAL_USE_DOMAINS = [
+  "local",
+  "example",
+  "invalid",
+  "localhost",
+  "test"
+];
+
 function permuteDomain(domain, allowSpecialUseDomain) {
   let pubSuf = null;
   if (allowSpecialUseDomain) {
     const domainParts = domain.split(".");
-    if (SPECIAL_USE_DOMAINS.includes(domainParts[domainParts.length - 1])) {
-      pubSuf = `${domainParts[domainParts.length - 2]}.${
-        domainParts[domainParts.length - 1]
-      }`;
+    // If the right-most label in the name is a special-use domain (e.g. bananas.apple.localhost),
+    // then don't use PSL. This is because most special-use domains are not listed on PSL.
+    const topLevelDomain = domainParts[domainParts.length - 1];
+    if (SPECIAL_USE_DOMAINS.includes(topLevelDomain)) {
+      const secondLevelDomain = domainParts[domainParts.length - 2];
+      // In aforementioned example, the eTLD/pubSuf will be apple.localhost
+      pubSuf = `${secondLevelDomain}.${topLevelDomain}`;
     } else {
       pubSuf = pubsuffix.getPublicSuffix(domain);
     }


### PR DESCRIPTION
Fix #174

I think @ruoho said he'd write a test case for #173 - once that is in I'll rebase off of that and add some more tests.

The hack in https://github.com/salesforce/tough-cookie/blob/master/lib/permuteDomain.js#L41 was introduced in #173 and is expanded in this PR because we rely on PSL's `psl.get()` call. This doesn't work for special-use domains because most of them are not in the Public Suffix List (except for `.onion`). Interestingly, `libpsl` (the C equivalent of the PSL js library we use) has a `isCookieDomainAcceptable()` function that would be useful - I raised an issue asking if there's interest in it for the PSL js library here: https://github.com/lupomontero/psl/issues/232