### PR TITLE
Issue #210 -- Updated workflow to use npm install.

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -22,5 +22,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies and test
-        run: npm ci
+        run: npm install
       - run: npm test


### PR DESCRIPTION
Have to make a change to the actions commands; `npm ci` only works if an install has already happened. :)