### PR TITLE
Unit test cases for `allowSpecialUseDomain` option

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1166,7 +1166,10 @@ class CookieJar {
 
     // S5.3 step 5: public suffixes
     if (this.rejectPublicSuffixes && cookie.domain) {
-      const suffix = pubsuffix.getPublicSuffix(cookie.cdomain());
+      const suffix = pubsuffix.getPublicSuffix(cookie.cdomain(), {
+        allowSpecialUseDomain: this.allowSpecialUseDomain,
+        ignoreError: options.ignoreError
+      });
       if (suffix == null && !IP_V6_REGEX_OBJECT.test(cookie.domain)) {
         // e.g. "com"
         err = new Error("Cookie has domain set to a public suffix");

--- a/lib/permuteDomain.js
+++ b/lib/permuteDomain.js
@@ -34,32 +34,10 @@ const pubsuffix = require("./pubsuffix-psl");
 // Gives the permutation of all possible domainMatch()es of a given domain. The
 // array is in shortest-to-longest order.  Handy for indexing.
 
-// RFC 6761
-const SPECIAL_USE_DOMAINS = [
-  "local",
-  "example",
-  "invalid",
-  "localhost",
-  "test"
-];
-
 function permuteDomain(domain, allowSpecialUseDomain) {
-  let pubSuf = null;
-  if (allowSpecialUseDomain) {
-    const domainParts = domain.split(".");
-    // If the right-most label in the name is a special-use domain (e.g. bananas.apple.localhost),
-    // then don't use PSL. This is because most special-use domains are not listed on PSL.
-    const topLevelDomain = domainParts[domainParts.length - 1];
-    if (SPECIAL_USE_DOMAINS.includes(topLevelDomain)) {
-      const secondLevelDomain = domainParts[domainParts.length - 2];
-      // In aforementioned example, the eTLD/pubSuf will be apple.localhost
-      pubSuf = `${secondLevelDomain}.${topLevelDomain}`;
-    } else {
-      pubSuf = pubsuffix.getPublicSuffix(domain);
-    }
-  } else {
-    pubSuf = pubsuffix.getPublicSuffix(domain);
-  }
+  const pubSuf = pubsuffix.getPublicSuffix(domain, {
+    allowSpecialUseDomain: allowSpecialUseDomain
+  });
 
   if (!pubSuf) {
     return null;

--- a/lib/pubsuffix-psl.js
+++ b/lib/pubsuffix-psl.js
@@ -31,7 +31,39 @@
 "use strict";
 const psl = require("psl");
 
-function getPublicSuffix(domain) {
+// RFC 6761
+const SPECIAL_USE_DOMAINS = [
+  "local",
+  "example",
+  "invalid",
+  "localhost",
+  "test"
+];
+
+function getPublicSuffix(domain, options = {}) {
+  const domainParts = domain.split(".");
+  const topLevelDomain = domainParts[domainParts.length - 1];
+  const allowSpecialUseDomain = !!options.allowSpecialUseDomain;
+  const ignoreError = !!options.ignoreError;
+
+  if (
+    allowSpecialUseDomain &&
+    domainParts.length > 1 &&
+    SPECIAL_USE_DOMAINS.includes(topLevelDomain)
+  ) {
+    // If the right-most label in the name is a special-use domain (e.g. bananas.apple.localhost),
+    // then don't use PSL. This is because most special-use domains are not listed on PSL.
+    const secondLevelDomain = domainParts[domainParts.length - 2];
+    // In aforementioned example, the eTLD/pubSuf will be apple.localhost
+    return `${secondLevelDomain}.${topLevelDomain}`;
+  }
+
+  if (!ignoreError && SPECIAL_USE_DOMAINS.includes(topLevelDomain)) {
+    throw new Error(
+      `Cookie has domain set to the public suffix "${topLevelDomain}" which is a special use domain. To allow this, configure your CookieJar with {allowSpecialUseDomain:true, rejectPublicSuffixes: false}.`
+    );
+  }
+
   return psl.get(domain);
 }
 


### PR DESCRIPTION
This PR adds test cases for the `allowSpecialUseDomain` option introduced in [PR #173](https://github.com/salesforce/tough-cookie/pull/173).  The special use domain check was changed to be a refinement on the public suffix check since both setting and retrieving cookies can fail since not all special use domains are considered public suffixes.

The following cases are tested:
* when the cookie jar is configured with `allowSpecialUseDomain=true`, the code will skip the lookup of a public suffix when a special use domain is detected
* when the cookie jar is configured with `allowSpecialUseDomain=false`, the code will raise an error describing proper usage when a special use domain is detected

Fixes #206 