### PR TITLE
fix: MemoryCookieStore methods should exist on the prototype, not on the class.

### DIFF
--- a/lib/memstore.js
+++ b/lib/memstore.js
@@ -184,7 +184,9 @@ class MemoryCookieStore extends Store {
   "removeAllCookies",
   "getAllCookies"
 ].forEach(name => {
-  MemoryCookieStore[name] = fromCallback(MemoryCookieStore.prototype[name]);
+  MemoryCookieStore.prototype[name] = fromCallback(
+    MemoryCookieStore.prototype[name]
+  );
 });
 
 exports.MemoryCookieStore = MemoryCookieStore;

--- a/test/regression_test.js
+++ b/test/regression_test.js
@@ -188,47 +188,61 @@ vows
       }
     }
   })
-  .addBatch({
-    "setCookie with localhost (GH-215)": {
-      topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=localhost", "http://localhost")  // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
-      },
-      works: function(err, c) {
-        // localhost as domain throws an error, cookie should not be defined
-        assert.instanceOf(err, Error)
-        assert.isUndefined(c)
-      }
-    }},
+  .addBatch(
     {
-    "setCookie with localhost (GH-215) (null domain)": {
-      topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=", "http://localhost")  // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
-      },
-      works: function(c) {
-        assert.instanceOf(c, Cookie)
+      "setCookie with localhost (GH-215)": {
+        topic: function() {
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync(
+            "a=b; Domain=localhost",
+            "http://localhost"
+          ); // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
+        },
+        works: function(err, c) {
+          // localhost as domain throws an error, cookie should not be defined
+          assert.instanceOf(err, Error);
+          assert.isUndefined(c);
+        }
       }
-    }},
-    { 
+    },
+    {
+      "setCookie with localhost (GH-215) (null domain)": {
+        topic: function() {
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync("a=b; Domain=", "http://localhost"); // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
+        },
+        works: function(c) {
+          assert.instanceOf(c, Cookie);
+        }
+      }
+    },
+    {
       "setCookie with localhost (localhost.local domain) (GH-215)": {
         topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=localhost.local", "http://localhost")
-      },
-      works: function(c) {
-        assert.instanceOf(c, Cookie)
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync(
+            "a=b; Domain=localhost.local",
+            "http://localhost"
+          );
+        },
+        works: function(c) {
+          assert.instanceOf(c, Cookie);
+        }
       }
-    }},
-    { 
+    },
+    {
       "setCookie with localhost (.localhost domain), (GH-215)": {
         topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=.localhost", "http://localhost")
-      },
-      works: function(c) {
-        assert.instanceOf(c, Cookie)
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync(
+            "a=b; Domain=.localhost",
+            "http://localhost"
+          );
+        },
+        works: function(c) {
+          assert.instanceOf(c, Cookie);
+        }
       }
     }
-  })
+  )
   .export(module);

--- a/test/regression_test.js
+++ b/test/regression_test.js
@@ -36,6 +36,7 @@ const async = require("async");
 const tough = require("../lib/cookie");
 const Cookie = tough.Cookie;
 const CookieJar = tough.CookieJar;
+const MemoryCookieStore = tough.MemoryCookieStore;
 
 const atNow = Date.now();
 
@@ -245,4 +246,25 @@ vows
       }
     }
   )
+  .addBatch({
+    MemoryCookieStore: {
+      topic: new MemoryCookieStore(),
+      "has no static methods": function() {
+        assert.deepEqual(Object.keys(MemoryCookieStore), []);
+      },
+      "has instance methods that return promises": function(store) {
+        assert.instanceOf(store.findCookie("example.com", "/", "key"), Promise);
+        assert.instanceOf(store.findCookies("example.com", "/"), Promise);
+        assert.instanceOf(store.putCookie({}), Promise);
+        assert.instanceOf(store.updateCookie({}, {}), Promise);
+        assert.instanceOf(
+          store.removeCookie("example.com", "/", "key"),
+          Promise
+        );
+        assert.instanceOf(store.removeCookies("example.com", "/"), Promise);
+        assert.instanceOf(store.removeAllCookies(), Promise);
+        assert.instanceOf(store.getAllCookies(), Promise);
+      }
+    }
+  })
   .export(module);


### PR DESCRIPTION
Also some linter auto-fixes adding noise to the test file. 😐  The test that I added starts on [line 249](https://github.com/salesforce/tough-cookie/pull/226/files#diff-89d2406f54a225979d07ba1f8d09d74faca4628e3b361b22143af303cec307efR249).