### PR TITLE
React Native Support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+  "extends": ["plugin:prettier/recommended"],
   "parserOptions": {
     "ecmaVersion": 6
   },
@@ -7,7 +8,14 @@
     "no-var": "error",
     "prefer-arrow-callback": "error",
     "prefer-const": "error",
-    "prefer-template": "error"
-  },
-  "extends": ["plugin:prettier/recommended"]
+    "prefer-template": "error",
+    "no-restricted-modules": ["error",
+      // we can't rely on node standard modules in "native" or "browser" environments
+      // - exceptions:
+      //     "punycode": since it's a package.json dependency
+      "assert", "buffer", "child_process", "cluster", "crypto", "dgram", "dns", "domain", "events", "freelist", "fs",
+      "http", "https", "module", "net", "os", "path", "querystring", "readline", "repl", "smalloc", "stream",
+      "string_decoder", "sys", "timers", "tls", "tracing", "tty", "url", "util", "vm", "zlib"
+    ]
+  }
 }

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -30,8 +30,8 @@
  */
 "use strict";
 const punycode = require("punycode");
-const urlParse = require("url").parse;
-const util = require("util");
+const urlParse = require("url-parse");
+const nodeUtil = require("./node-util");
 const pubsuffix = require("./pubsuffix-psl");
 const Store = require("./store").Store;
 const MemoryCookieStore = require("./memstore").MemoryCookieStore;
@@ -810,6 +810,7 @@ const cookieDefaults = {
 
 class Cookie {
   constructor(options = {}) {
+    const util = nodeUtil();
     if (util.inspect.custom) {
       this[util.inspect.custom] = this.inspect;
     }
@@ -1110,7 +1111,7 @@ class CookieJar {
   }
 
   setCookie(cookie, url, options, cb) {
-    validators.validate(validators.isNonEmptyString(url), cb, options);   
+    validators.validate(validators.isNonEmptyString(url), cb, options);
     let err;
 
     if (validators.isFunction(url)) {
@@ -1646,7 +1647,7 @@ class CookieJar {
       serialized = strOrObj;
     }
 
-    const jar = new CookieJar(store, { 
+    const jar = new CookieJar(store, {
       rejectPublicSuffixes: serialized.rejectPublicSuffixes,
       looseMode: serialized.enableLooseMode,
       allowSpecialUseDomain: serialized.allowSpecialUseDomain,
@@ -1663,9 +1664,9 @@ class CookieJar {
   static deserializeSync(strOrObj, store) {
     const serialized =
       typeof strOrObj === "string" ? JSON.parse(strOrObj) : strOrObj;
-    const jar = new CookieJar(store, { 
+    const jar = new CookieJar(store, {
       rejectPublicSuffixes: serialized.rejectPublicSuffixes,
-      looseMode: serialized.enableLooseMode 
+      looseMode: serialized.enableLooseMode
     });
 
     // catch this mistake early:

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -99,7 +99,7 @@ const PrefixSecurityEnum = Object.freeze({
 // * all capturing groups converted to non-capturing -- "(?:)"
 // * support for IPv6 Scoped Literal ("%eth1") removed
 // * lowercase hexadecimal only
-const IP_REGEX_LOWERCASE =/(?:^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$)|(?:^(?:(?:[a-f\d]{1,4}:){7}(?:[a-f\d]{1,4}|:)|(?:[a-f\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-f\d]{1,4}|:)|(?:[a-f\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,2}|:)|(?:[a-f\d]{1,4}:){4}(?:(?::[a-f\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,3}|:)|(?:[a-f\d]{1,4}:){3}(?:(?::[a-f\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,4}|:)|(?:[a-f\d]{1,4}:){2}(?:(?::[a-f\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,5}|:)|(?:[a-f\d]{1,4}:){1}(?:(?::[a-f\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,6}|:)|(?::(?:(?::[a-f\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,7}|:)))$)/;
+const IP_REGEX_LOWERCASE = /(?:^(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}$)|(?:^(?:(?:[a-f\d]{1,4}:){7}(?:[a-f\d]{1,4}|:)|(?:[a-f\d]{1,4}:){6}(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|:[a-f\d]{1,4}|:)|(?:[a-f\d]{1,4}:){5}(?::(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,2}|:)|(?:[a-f\d]{1,4}:){4}(?:(?::[a-f\d]{1,4}){0,1}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,3}|:)|(?:[a-f\d]{1,4}:){3}(?:(?::[a-f\d]{1,4}){0,2}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,4}|:)|(?:[a-f\d]{1,4}:){2}(?:(?::[a-f\d]{1,4}){0,3}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,5}|:)|(?:[a-f\d]{1,4}:){1}(?:(?::[a-f\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,6}|:)|(?::(?:(?::[a-f\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d|\d)){3}|(?::[a-f\d]{1,4}){1,7}|:)))$)/;
 const IP_V6_REGEX = `
 \\[?(?:
 (?:[a-fA-F\\d]{1,4}:){7}(?:[a-fA-F\\d]{1,4}|:)|
@@ -111,9 +111,11 @@ const IP_V6_REGEX = `
 (?:[a-fA-F\\d]{1,4}:){1}(?:(?::[a-fA-F\\d]{1,4}){0,4}:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,6}|:)|
 (?::(?:(?::[a-fA-F\\d]{1,4}){0,5}:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)(?:\\.(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]\\d|\\d)){3}|(?::[a-fA-F\\d]{1,4}){1,7}|:))
 )(?:%[0-9a-zA-Z]{1,})?\\]?
-`.replace(/\s*\/\/.*$/gm, '').replace(/\n/g, '').trim();
-const IP_V6_REGEX_OBJECT = new RegExp(`^${IP_V6_REGEX}$`)
-
+`
+  .replace(/\s*\/\/.*$/gm, "")
+  .replace(/\n/g, "")
+  .trim();
+const IP_V6_REGEX_OBJECT = new RegExp(`^${IP_V6_REGEX}$`);
 
 /*
  * Parses a Natural number (i.e., non-negative integer) with either the
@@ -380,7 +382,7 @@ function domainMatch(str, domStr, canonicalize) {
 
   /* "  * The last character of the string that is not included in the
    * domain string is a %x2E (".") character." */
-  if (str.substr(idx-1,1) !== '.') {
+  if (str.substr(idx - 1, 1) !== ".") {
     return false; // doesn't align on "."
   }
 
@@ -479,7 +481,7 @@ function parse(str, options) {
   }
 
   if (validators.isEmptyString(str) || !validators.isString(str)) {
-    return null
+    return null;
   }
 
   str = str.trim();
@@ -1127,7 +1129,12 @@ class CookieJar {
 
     validators.validate(validators.isFunction(cb), cb);
 
-    if(!validators.isNonEmptyString(cookie) && !validators.isObject(cookie) && ( cookie instanceof String && cookie.length == 0)) {
+    if (
+      !validators.isNonEmptyString(cookie) &&
+      !validators.isObject(cookie) &&
+      cookie instanceof String &&
+      cookie.length == 0
+    ) {
       return cb(null);
     }
 

--- a/lib/memstore.js
+++ b/lib/memstore.js
@@ -33,19 +33,21 @@ const { fromCallback } = require("universalify");
 const Store = require("./store").Store;
 const permuteDomain = require("./permuteDomain").permuteDomain;
 const pathMatch = require("./pathMatch").pathMatch;
-const util = require("util");
+const nodeUtil = require("./node-util");
 
 class MemoryCookieStore extends Store {
   constructor() {
     super();
     this.synchronous = true;
     this.idx = {};
+    const util = nodeUtil();
     if (util.inspect.custom) {
       this[util.inspect.custom] = this.inspect;
     }
   }
 
   inspect() {
+    const util = nodeUtil();
     return `{ idx: ${util.inspect(this.idx, false, 2)} }`;
   }
 

--- a/lib/node-util.js
+++ b/lib/node-util.js
@@ -1,0 +1,20 @@
+// a stand-in for util that does nothing but prevent the existing
+// node:util code paths from exploding
+function nullUtilInspect() {
+  return "";
+}
+nullUtilInspect.custom = Symbol.for("nodejs.util.inspect.custom");
+const nullUtil = { inspect: nullUtilInspect };
+
+module.exports = function nodeUtil() {
+  try {
+    const jscCompatibility =
+      process && process.env && process.env.JSC_COMPATIBILITY === "enabled";
+    if (!jscCompatibility) {
+      return require("util");
+    }
+  } catch (e) {
+    // ignore
+  }
+  return nullUtil;
+};

--- a/lib/node-util.js
+++ b/lib/node-util.js
@@ -9,12 +9,14 @@ const nullUtil = { inspect: nullUtilInspect };
 module.exports = function nodeUtil() {
   try {
     const jscCompatibility =
-      process && process.env && process.env.JSC_COMPATIBILITY === "enabled";
+      process && process.env && process.env.NODE_UTIL_FALLBACK === "enabled";
     if (!jscCompatibility) {
+      // we want the real "util" module if we are in a node environment
+      // eslint-disable-next-line no-restricted-modules
       return require("util");
     }
   } catch (e) {
-    // ignore
+    // ignored
   }
   return nullUtil;
 };

--- a/lib/permuteDomain.js
+++ b/lib/permuteDomain.js
@@ -70,7 +70,7 @@ function permuteDomain(domain, allowSpecialUseDomain) {
 
   // Nuke trailing dot
   if (domain.slice(-1) == ".") {
-    domain = domain.slice(0, -1)
+    domain = domain.slice(0, -1);
   }
 
   const prefix = domain.slice(0, -(pubSuf.length + 1)); // ".example.com"

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -1,21 +1,21 @@
 /* ************************************************************************************
 Extracted from check-types.js
 https://gitlab.com/philbooth/check-types.js
- 
+
 MIT License
- 
+
 Copyright (c) 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019 Phil Booth
- 
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
- 
+
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
- 
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,17 +23,17 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
- 
+
 ************************************************************************************ */
 "use strict";
 
 /* Validation functions copied from check-types package - https://www.npmjs.com/package/check-types */
 function isFunction(data) {
-  return typeof data === 'function';
+  return typeof data === "function";
 }
 
 function isNonEmptyString(data) {
-  return isString(data) && data !== '';
+  return isString(data) && data !== "";
 }
 
 function isDate(data) {
@@ -41,15 +41,15 @@ function isDate(data) {
 }
 
 function isEmptyString(data) {
-  return data === '' || (data instanceof String && data.toString() === '');
+  return data === "" || (data instanceof String && data.toString() === "");
 }
 
 function isString(data) {
-  return typeof data === 'string' || data instanceof String
+  return typeof data === "string" || data instanceof String;
 }
 
 function isObject(data) {
-  return toString.call(data) === '[object Object]';
+  return toString.call(data) === "[object Object]";
 }
 function isInstanceStrict(data, prototype) {
   try {
@@ -60,7 +60,7 @@ function isInstanceStrict(data, prototype) {
 }
 
 function isInteger(data) {
-  return typeof data === 'number' && data % 1 === 0;
+  return typeof data === "number" && data % 1 === 0;
 }
 /* End validation functions */
 
@@ -83,7 +83,7 @@ class ParameterError extends Error {
   constructor(...params) {
     super(...params);
   }
-};
+}
 
 exports.ParameterError = ParameterError;
 exports.isFunction = isFunction;

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   ],
   "scripts": {
     "version": "genversion lib/version.js && git add lib/version.js",
-    "test": "vows test/*_test.js",
+    "test": "vows test/*_test.js && npm run eslint",
     "cover": "nyc --reporter=lcov --reporter=html vows test/*_test.js",
     "eslint": "eslint --env node --ext .js .",
     "prettier": "prettier '**/*.{json,ts,yaml,md}'",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "dependencies": {
     "psl": "^1.1.33",
     "punycode": "^2.1.1",
-    "universalify": "^0.1.2"
+    "universalify": "^0.1.2",
+    "url-parse": "^1.5.3"
   }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-restricted-modules": "off"
+  }
+}

--- a/test/cookie_jar_test.js
+++ b/test/cookie_jar_test.js
@@ -281,7 +281,7 @@ vows
         assert.equal(c.TTL(), Infinity);
         assert.ok(!c.isPersistent());
       }
-    },
+    }
   })
   .addBatch({
     "Store eight cookies": {
@@ -750,18 +750,21 @@ vows
       "of undefined": {
         topic: function() {
           const jar = new tough.CookieJar();
-          const cookieString = `AWSELB=69b2c0038b16e8e27056d1178e0d556c; 
-          Path=/, jses_WS41=5f8dc2f6-ea37-49de-8dfa-b58336c2d9ce; path=/; 
+          const cookieString = `AWSELB=69b2c0038b16e8e27056d1178e0d556c;
+          Path=/, jses_WS41=5f8dc2f6-ea37-49de-8dfa-b58336c2d9ce; path=/;
           Secure; HttpOnly, AuthToken=EFKFFFCH@K@GHIHEJCJMMGJM>CDHDEK>CFGK?MHJ
           >>JI@B??@CAEHBJH@H@A@GCFDLIMLJEEJEIFGALA?BIM?@G@DEDI@JE?I?HKJBIDDHJMEFEFM
-          >G@J?I??B@C>>LAH?GCGJ@FMEGHBGAF; expires=Sun, 31-Jan-9021 02:39:04 GMT; 
-          path=/; Secure; HttpOnly, FirstReferrer=; expires=Fri, 31-Jan-9020 20:50:44 
+          >G@J?I??B@C>>LAH?GCGJ@FMEGHBGAF; expires=Sun, 31-Jan-9021 02:39:04 GMT;
+          path=/; Secure; HttpOnly, FirstReferrer=; expires=Fri, 31-Jan-9020 20:50:44
           GMT; path=/`;
 
           jar.setCookieSync(cookieString, "https://google.com");
-          jar.getCookies("https://google.com", this.callback)
+          jar.getCookies("https://google.com", this.callback);
         },
-        "results in a 1-length array with a valid cookie": function(err, cookies) {
+        "results in a 1-length array with a valid cookie": function(
+          err,
+          cookies
+        ) {
           assert(!err, err);
           assert(cookies.length == 1);
           assert.instanceOf(cookies[0], Cookie);
@@ -780,7 +783,10 @@ vows
             this.callback
           );
         },
-        "results in a error being returned because of missing parameters": function(err, cookies) {
+        "results in a error being returned because of missing parameters": function(
+          err,
+          cookies
+        ) {
           assert(err != null);
           assert(err instanceof tough.ParameterError);
         }
@@ -792,13 +798,12 @@ vows
       "with missing parameters": {
         topic: function() {
           const jar = new tough.CookieJar();
-          jar.setCookie(
-            '',
-            "https://google.com",
-            this.callback
-          );
+          jar.setCookie("", "https://google.com", this.callback);
         },
-        "results in a error being returned because of missing parameters": function(err, cookies) {
+        "results in a error being returned because of missing parameters": function(
+          err,
+          cookies
+        ) {
           assert(cookies == undefined);
         }
       }

--- a/test/domain_and_path_test.js
+++ b/test/domain_and_path_test.js
@@ -50,15 +50,15 @@ function matchVows(func, table) {
 }
 
 function transformVows(fn, table) {
-  var theVows = {};
-  table.forEach(function (item) {
-    var str = item[0];
-    var expect = item[1];
-    var label = str + " gives " + expect;
+  const theVows = {};
+  table.forEach(item => {
+    const str = item[0];
+    const expect = item[1];
+    let label = `${str} gives ${expect}`;
     if (item.length >= 3) {
-      label += " (" + item[2] + ")";
+      label += ` (${item[2]})`;
     }
-    theVows[label] = function () {
+    theVows[label] = function() {
       assert.equal(fn(str), expect);
     };
   });
@@ -75,7 +75,7 @@ vows
       ["EXAMPLE.com.", "example.com.", "trailing dot"],
       [".EXAMPLE.com.", "example.com.", "leading and trailing dot"],
       [".EXAMPLE...com.", "example...com.", "internal dots"],
-      ["δοκιμή.δοκιμή","xn--jxalpdlp.xn--jxalpdlp", "IDN: test.test in greek"],
+      ["δοκιμή.δοκιμή", "xn--jxalpdlp.xn--jxalpdlp", "IDN: test.test in greek"]
     ])
   })
   .addBatch({
@@ -142,12 +142,12 @@ vows
       // exact length "TLD" tests:
       ["com", "net", false], // same len, non-match
       ["com", "com", true], // "are identical" rule
-      ["NOTATLD", "notaTLD", true], // "are identical" rule (after canonicalization)
+      ["NOTATLD", "notaTLD", true] // "are identical" rule (after canonicalization)
     ])
   })
 
   .addBatch({
-    "default-path": transformVows(tough.defaultPath,[
+    "default-path": transformVows(tough.defaultPath, [
       [null, "/"],
       ["/", "/"],
       ["/file", "/"],

--- a/test/jsc_compatibility_test.js
+++ b/test/jsc_compatibility_test.js
@@ -1,0 +1,58 @@
+/*!
+ * Copyright (c) 2015, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of Salesforce.com nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+"use strict";
+const vows = require("vows");
+const assert = require("assert");
+const tough = require("../lib/cookie");
+const util = require("util");
+const nodeUtil = require("../lib/node-util");
+const Cookie = tough.Cookie;
+
+vows
+  .describe("JavaScriptCore Compatibility")
+  .addBatch({
+    util: {
+      topic: function() {
+        process.env.JSC_COMPATIBILITY = "enabled";
+        return new Cookie();
+      },
+      "should not error out on util.* code paths": function(c) {
+        const nullUtil = nodeUtil();
+        assert.equal(nullUtil.inspect(c), "");
+        assert.equal(nullUtil.inspect.custom, util.inspect.custom);
+      },
+      teardown: function() {
+        delete process.env.JSC_COMPATIBILITY;
+      }
+    }
+  })
+  .export(module);

--- a/test/node_util_fallback_test.js
+++ b/test/node_util_fallback_test.js
@@ -42,7 +42,7 @@ vows
   .addBatch({
     util: {
       topic: function() {
-        process.env.JSC_COMPATIBILITY = "enabled";
+        process.env.NODE_UTIL_FALLBACK = "enabled";
         return new Cookie();
       },
       "should not error out on util.* code paths": function(c) {
@@ -51,7 +51,7 @@ vows
         assert.equal(nullUtil.inspect.custom, util.inspect.custom);
       },
       teardown: function() {
-        delete process.env.JSC_COMPATIBILITY;
+        delete process.env.NODE_UTIL_FALLBACK;
       }
     }
   })

--- a/test/parsing_test.js
+++ b/test/parsing_test.js
@@ -693,35 +693,35 @@ vows
       }
     },
     "empty string": {
-      topic: function () {
-        return Cookie.parse('');
+      topic: function() {
+        return Cookie.parse("");
       },
-      "is empty": function (c) {
+      "is empty": function(c) {
         assert.isNull(c);
       }
     },
     "missing string": {
-      topic: function () {
+      topic: function() {
         return Cookie.parse();
       },
-      "is empty": function (c) {
+      "is empty": function(c) {
         assert.isNull(c);
       }
     },
     "some string object": {
       topic: function() {
-        return Cookie.parse(new String(''))
+        return Cookie.parse(new String(""));
       },
       "is empty": function(c) {
-        assert.isNull(c,null)
+        assert.isNull(c, null);
       }
     },
     "some empty string object": {
       topic: function() {
-        return Cookie.parse(new String())
+        return Cookie.parse(new String());
       },
       "is empty": function(c) {
-        assert.isNull(c,null)
+        assert.isNull(c, null);
       }
     }
   })

--- a/test/regression_test.js
+++ b/test/regression_test.js
@@ -188,47 +188,61 @@ vows
       }
     }
   })
-  .addBatch({
-    "setCookie with localhost (GH-215)": {
-      topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=localhost", "http://localhost")  // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
-      },
-      works: function(err, c) {
-        // localhost as domain throws an error, cookie should not be defined
-        assert.instanceOf(err, Error)
-        assert.isUndefined(c)
-      }
-    }},
+  .addBatch(
     {
-    "setCookie with localhost (GH-215) (null domain)": {
-      topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=", "http://localhost")  // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
-      },
-      works: function(c) {
-        assert.instanceOf(c, Cookie)
+      "setCookie with localhost (GH-215)": {
+        topic: function() {
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync(
+            "a=b; Domain=localhost",
+            "http://localhost"
+          ); // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
+        },
+        works: function(err, c) {
+          // localhost as domain throws an error, cookie should not be defined
+          assert.instanceOf(err, Error);
+          assert.isUndefined(c);
+        }
       }
-    }},
-    { 
+    },
+    {
+      "setCookie with localhost (GH-215) (null domain)": {
+        topic: function() {
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync("a=b; Domain=", "http://localhost"); // when domain set to 'localhost', will throw 'Error: Cookie has domain set to a public suffix'
+        },
+        works: function(c) {
+          assert.instanceOf(c, Cookie);
+        }
+      }
+    },
+    {
       "setCookie with localhost (localhost.local domain) (GH-215)": {
         topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=localhost.local", "http://localhost")
-      },
-      works: function(c) {
-        assert.instanceOf(c, Cookie)
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync(
+            "a=b; Domain=localhost.local",
+            "http://localhost"
+          );
+        },
+        works: function(c) {
+          assert.instanceOf(c, Cookie);
+        }
       }
-    }},
-    { 
+    },
+    {
       "setCookie with localhost (.localhost domain), (GH-215)": {
         topic: function() {
-        const cookieJar = new CookieJar();
-        return cookieJar.setCookieSync("a=b; Domain=.localhost", "http://localhost")
-      },
-      works: function(c) {
-        assert.instanceOf(c, Cookie)
+          const cookieJar = new CookieJar();
+          return cookieJar.setCookieSync(
+            "a=b; Domain=.localhost",
+            "http://localhost"
+          );
+        },
+        works: function(c) {
+          assert.instanceOf(c, Cookie);
+        }
       }
     }
-  })
+  )
   .export(module);


### PR DESCRIPTION
This PR fixes #222 by:
 - introducing a fallback for the `util` module code paths used as indicated in [this comment](https://github.com/lb90/tough-cookie/commit/b43b4e9ad25dfc6e035cc50723f39cf3477facae)
 - adding a dependency on [`url-parse`](https://www.npmjs.com/package/url-parse) to act as a polyfill for the usage of `require('url').parse`
 - configuring eslint to error on [`no-restricted-modules`](https://eslint.org/docs/rules/no-restricted-modules) which will not be present in native environments