### PR TITLE
fix: domain match routine

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -368,7 +368,7 @@ function domainMatch(str, domStr, canonicalize) {
   /* " o All of the following [three] conditions hold:" */
 
   /* "* The domain string is a suffix of the string" */
-  const idx = str.indexOf(domStr);
+  const idx = str.lastIndexOf(domStr);
   if (idx <= 0) {
     return false; // it's a non-match (-1) or prefix (0)
   }

--- a/test/domain_and_path_test.js
+++ b/test/domain_and_path_test.js
@@ -33,7 +33,6 @@
 const vows = require("vows");
 const assert = require("assert");
 const tough = require("../lib/cookie");
-const Cookie = tough.Cookie;
 
 function matchVows(func, table) {
   const theVows = {};
@@ -105,6 +104,9 @@ vows
       ["www.aaaa.com", "aaa.com", false],
       ["www.aaa.com", "aaa.com", true],
       ["www.aexample.com", "example.com", false], // has to match on "." boundary
+      ["computer.com", "com", true], // suffix string found at start of domain
+      ["becoming.com", "com", true], // suffix string found in middle of domain
+      ["sitcom.com", "com", true], // suffix string found just before the '.' boundary
 
       // S5.1.3 "The string is a host name (i.e., not an IP address)"
       ["192.168.0.1", "168.0.1", false], // because str is an IP (v4)


### PR DESCRIPTION
The domain match routine can fail in cases where the domain suffix characters can be located in the string before the suffix. Changing the logic to use `lastIndexOf` instead of `indexOf` seems more appropriate for testing the suffix here.

Fixes #235 