### PR TITLE
Stop using the internal NodeJS punycode module

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -29,7 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 "use strict";
-const punycode = require("punycode");
+const punycode = require("punycode/");
 const urlParse = require("url-parse");
 const pubsuffix = require("./pubsuffix-psl");
 const Store = require("./store").Store;


### PR DESCRIPTION
The way the code is right now, it doesn't use the Punycode package, but the internal NodeJS punycode module. That is deprecated now, which is why I saw the warning popping up (for the ones googling this, the warning is "DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead"). According to the docs of the Punycode package, you need to use `require('punycode/')`, to use the Punycode package rather than the internal NodeJS module, see https://github.com/mathiasbynens/punycode.js#installation.