### PR TITLE
Prepare tough-cookie 4.1 for publishing (updated GitHub actions, move…

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:16
 MAINTAINER awaterman@salesforce.com
 LABEL Description="Vendor=\"Salesforce.com\" Version=\"1.0\""
 RUN apt-get update && \


### PR DESCRIPTION
… Dockerfile version to Node:16)