### PR TITLE
fix: allow special use domains by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ The `options` object can be omitted and can have the following properties:
 - _rejectPublicSuffixes_ - boolean - default `true` - reject cookies with domains like "com" and "co.uk"
 - _looseMode_ - boolean - default `false` - accept malformed cookies like `bar` and `=bar`, which have an implied empty name.
 - _prefixSecurity_ - string - default `silent` - set to `'unsafe-disabled'`, `'silent'`, or `'strict'`. See [Cookie Prefixes](#cookie-prefixes) below.
-- _allowSpecialUseDomain_ - boolean - default `false` - accepts special-use domain suffixes, such as `local`. Useful for testing purposes.
+- _allowSpecialUseDomain_ - boolean - default `true` - accepts special-use domain suffixes, such as `local`. Useful for testing purposes.
   This is not in the standard, but is used sometimes on the web and is accepted by most browsers.
 
 #### `.setCookie(cookieOrString, currentUrl[, options][, callback(err, cookie)])`

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1099,7 +1099,10 @@ class CookieJar {
     validators.validate(validators.isObject(options), options);
     this.rejectPublicSuffixes = options.rejectPublicSuffixes;
     this.enableLooseMode = !!options.looseMode;
-    this.allowSpecialUseDomain = !!options.allowSpecialUseDomain;
+    this.allowSpecialUseDomain =
+      typeof options.allowSpecialUseDomain === "boolean"
+        ? options.allowSpecialUseDomain
+        : true;
     this.store = store || new MemoryCookieStore();
     this.prefixSecurity = getNormalizedPrefixSecurity(options.prefixSecurity);
     this._cloneSync = syncWrap("clone");

--- a/lib/memstore.js
+++ b/lib/memstore.js
@@ -64,7 +64,7 @@ class MemoryCookieStore extends Store {
     const results = [];
     if (typeof allowSpecialUseDomain === "function") {
       cb = allowSpecialUseDomain;
-      allowSpecialUseDomain = false;
+      allowSpecialUseDomain = true;
     }
     if (!domain) {
       return cb(null, []);

--- a/test/api_test.js
+++ b/test/api_test.js
@@ -593,6 +593,46 @@ function allowSpecialUseOptionVows() {
 
   return specialUseDomains.reduce((vows, specialUseDomain) => {
     vows[
+      `cookie jar with allowSpecialUseDomain set to the default value and domain is "${specialUseDomain}"`
+    ] = {
+      topic: function() {
+        const cb = this.callback;
+        const cj = new CookieJar();
+        cj.setCookie(
+          `settingThisShouldPass=true; Domain=dev.${specialUseDomain}; Path=/;`,
+          `http://dev.${specialUseDomain}`,
+          at(-1),
+          (err, cookie) => {
+            cb(err, { cj: cj, cookie: cookie });
+          }
+        );
+      },
+      "set the cookie": function(t) {
+        assert.ok(t.cookie, "didn't set?!");
+        assert.equal(t.cookie.key, "settingThisShouldPass");
+      },
+      "then, retrieving": {
+        topic: function(t) {
+          const cb = this.callback;
+          setTimeout(() => {
+            t.cj.getCookies(
+              `http://dev.${specialUseDomain}`,
+              { http: true },
+              (err, cookies) => {
+                t.cookies = cookies;
+                cb(err, t);
+              }
+            );
+          }, 2000);
+        },
+        "got the cookie": function(t) {
+          assert.lengthOf(t.cookies, 1);
+          assert.equal(t.cookies[0].key, "settingThisShouldPass");
+        }
+      }
+    };
+
+    vows[
       `cookie jar with allowSpecialUseDomain enabled and domain is "${specialUseDomain}"`
     ] = {
       topic: function() {


### PR DESCRIPTION
To avoid breaking behavior the `allowSpecialUseDomain` option should have been set to `true` by default.

This PR also adds tests that cover when a default `CookieStore` is created it does allow cookies with special use domains.

closes #246