### PR TITLE
Fix prettier in eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     //"plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "prettier"
+    "plugin:prettier/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {

--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -29,7 +29,14 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Cookie, CookieJar, MemoryCookieStore, ParameterError, SerializedCookieJar, Store } from "../cookie";
+import {
+  Cookie,
+  CookieJar,
+  MemoryCookieStore,
+  ParameterError,
+  SerializedCookieJar,
+  Store,
+} from '../cookie'
 
 jest.useFakeTimers()
 
@@ -66,7 +73,10 @@ describe('CookieJar', () => {
           cookie = await cookieJar.setCookie('foo=bar', 'http://example.com')
         },
         syncStyle() {
-          const result = cookieJar.setCookieSync('foo=bar', 'http://example.com')
+          const result = cookieJar.setCookieSync(
+            'foo=bar',
+            'http://example.com',
+          )
           if (result == null) {
             throw new Error('Result should not have been undefined')
           }
@@ -368,7 +378,7 @@ describe('CookieJar', () => {
             cookies = cookieJar.getCookiesSync('http://example.com')
           },
         },
-        ()=> {
+        () => {
           expect(cookies).toEqual([
             expect.objectContaining({
               key: 'foo',
@@ -947,7 +957,7 @@ describe('CookieJar', () => {
         syncStyle() {
           const result = cookieJar.serializeSync()
           if (!result) {
-            throw new Error("This should have been undefined")
+            throw new Error('This should have been undefined')
           }
           data = result
         },
@@ -1118,7 +1128,7 @@ describe('loose mode', () => {
     const cookieJar = new CookieJar(null, { looseMode: true })
     const cookieJarAsJson = cookieJar.toJSON()
     if (!cookieJarAsJson) {
-      throw new Error("This should not have been undefined")
+      throw new Error('This should not have been undefined')
     }
     const clonedCookieJar = CookieJar.fromJSON(cookieJarAsJson)
     await clonedCookieJar.setCookie('FooBar', 'http://www.foonet.net')
@@ -1249,7 +1259,7 @@ describe.each(['local', 'example', 'invalid', 'localhost', 'test'])(
         )
       } catch (e) {
         if (!(e instanceof Error)) {
-          throw new Error("This should be an error instance")
+          throw new Error('This should be an error instance')
         }
         expect(e.message).toBe(
           `Cookie has domain set to the public suffix "${specialUseDomain}" which is a special use domain. To allow this, configure your CookieJar with {allowSpecialUseDomain:true, rejectPublicSuffixes: false}.`,
@@ -1300,7 +1310,7 @@ describe.each(['local', 'example', 'invalid', 'localhost', 'test'])(
           )
         } catch (e) {
           if (!(e instanceof Error)) {
-            throw new Error("This should be an error instance")
+            throw new Error('This should be an error instance')
           }
           expect(e.message).toBe(
             `Cookie has domain set to the public suffix "${specialUseDomain}" which is a special use domain. To allow this, configure your CookieJar with {allowSpecialUseDomain:true, rejectPublicSuffixes: false}.`,
@@ -1348,7 +1358,7 @@ describe.each(['local', 'example', 'invalid', 'localhost', 'test'])(
           )
         } catch (e) {
           if (!(e instanceof Error)) {
-            throw new Error("This should be an error instance")
+            throw new Error('This should be an error instance')
           }
           expect(e.message).toBe(
             `Cookie has domain set to the public suffix "${specialUseDomain}" which is a special use domain. To allow this, configure your CookieJar with {allowSpecialUseDomain:true, rejectPublicSuffixes: false}.`,
@@ -1370,7 +1380,7 @@ describe.each(['local', 'example', 'invalid', 'localhost', 'test'])(
         )
       } catch (e) {
         if (!(e instanceof Error)) {
-          throw new Error("This should be an error instance")
+          throw new Error('This should be an error instance')
         }
         expect(e.message).toBe(
           `Cookie has domain set to the public suffix "${specialUseDomain}" which is a special use domain. To allow this, configure your CookieJar with {allowSpecialUseDomain:true, rejectPublicSuffixes: false}.`,
@@ -1424,7 +1434,7 @@ function createCookie(
 ): Cookie {
   const cookie = Cookie.parse(cookieString)
   if (!cookie) {
-    throw new Error("This should not be undefined")
+    throw new Error('This should not be undefined')
   }
   if (options?.hostOnly) {
     cookie.hostOnly = options.hostOnly

--- a/lib/__tests__/cookiePrefixes.spec.ts
+++ b/lib/__tests__/cookiePrefixes.spec.ts
@@ -1,4 +1,4 @@
-import { CookieJar, PrefixSecurityEnum } from "../cookie";
+import { CookieJar, PrefixSecurityEnum } from '../cookie'
 
 let cookieJar: CookieJar
 const insecureUrl = 'http://www.example.com'

--- a/lib/__tests__/cookieSorting.spec.ts
+++ b/lib/__tests__/cookieSorting.spec.ts
@@ -9,7 +9,9 @@ describe('Cookie sorting', () => {
       const cookie2 = new Cookie()
       expect(typeof cookie1.creationIndex).toBe('number')
       expect(typeof cookie2.creationIndex).toBe('number')
-      expect(cookie1.creationIndex).toBeLessThan(cookie2.creationIndex as number)
+      expect(cookie1.creationIndex).toBeLessThan(
+        cookie2.creationIndex as number,
+      )
     })
 
     it('should set the creation index during construction when creation time is provided', () => {
@@ -19,7 +21,9 @@ describe('Cookie sorting', () => {
       expect(cookie1.creation).toEqual(cookie2.creation)
       expect(typeof cookie1.creationIndex).toBe('number')
       expect(typeof cookie2.creationIndex).toBe('number')
-      expect(cookie1.creationIndex).toBeLessThan(cookie2.creationIndex as number)
+      expect(cookie1.creationIndex).toBeLessThan(
+        cookie2.creationIndex as number,
+      )
     })
 
     it('should leave the creation index alone during setCookie', async () => {

--- a/lib/__tests__/cookieToAndFromJson.spec.ts
+++ b/lib/__tests__/cookieToAndFromJson.spec.ts
@@ -1,4 +1,4 @@
-import { Cookie } from "../cookie";
+import { Cookie } from '../cookie'
 
 jest.useFakeTimers()
 
@@ -8,7 +8,7 @@ describe('Cookie.toJSON()', () => {
       'alpha=beta; Domain=example.com; Path=/foo; Expires=Tue, 19 Jan 2038 03:14:07 GMT; HttpOnly',
     )
     if (!cookie) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     expect(cookie.toJSON()).toEqual({
       creation: new Date().toISOString(),
@@ -44,8 +44,8 @@ describe('Cookie.fromJSON()', () => {
         path: '/foo',
         value: 'beta',
         lastAccessed: new Date(2000000000123),
-      },
-    ))
+      }),
+    )
   })
 
   it('should be able to handle a null value deserialization', () => {
@@ -60,7 +60,7 @@ describe('Cookie.fromJSON()', () => {
     })
     const cookie = Cookie.fromJSON(json)
     if (!cookie) {
-      throw new Error("This should not be null")
+      throw new Error('This should not be null')
     }
     expect(cookie.expires).toBe('Infinity')
     expect(cookie.creation).toBe('Infinity')

--- a/lib/__tests__/cookieToString.spec.ts
+++ b/lib/__tests__/cookieToString.spec.ts
@@ -1,10 +1,10 @@
-import { Cookie } from "../cookie";
+import { Cookie } from '../cookie'
 
 describe('Cookie.toString()', () => {
   const parse = (cookieString: string): Cookie => {
     const cookie = Cookie.parse(cookieString)
     if (!cookie) {
-      throw new Error("This should have parsed")
+      throw new Error('This should have parsed')
     }
     return cookie
   }

--- a/lib/__tests__/data/dates/bsd-examples.ts
+++ b/lib/__tests__/data/dates/bsd-examples.ts
@@ -1,168 +1,222 @@
 export default [
   {
-    "test": "Sat, 15-Apr-17 21:01:22 GMT",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Thu, 19-Apr-2007 16:00:00 GMT",
-    "expected": "Thu, 19 Apr 2007 16:00:00 GMT"
-  }, {
-    "test": "Wed, 25 Apr 2007 21:02:13 GMT",
-    "expected": "Wed, 25 Apr 2007 21:02:13 GMT"
-  }, {
-    "test": "Thu, 19/Apr\\2007 16:00:00 GMT",
-    "expected": "Thu, 19 Apr 2007 16:00:00 GMT"
-  }, {
-    "test": "Fri, 1 Jan 2010 01:01:50 GMT",
-    "expected": "Fri, 01 Jan 2010 01:01:50 GMT"
-  }, {
-    "test": "Wednesday, 1-Jan-2003 00:00:00 GMT",
-    "expected": "Wed, 01 Jan 2003 00:00:00 GMT"
-  }, {
-    "test": ", 1-Jan-2003 00:00:00 GMT",
-    "expected": "Wed, 01 Jan 2003 00:00:00 GMT"
-  }, {
-    "test": " 1-Jan-2003 00:00:00 GMT",
-    "expected": "Wed, 01 Jan 2003 00:00:00 GMT"
-  }, {
-    "test": "1-Jan-2003 00:00:00 GMT",
-    "expected": "Wed, 01 Jan 2003 00:00:00 GMT"
-  }, {
-    "test": "Wed,18-Apr-07 22:50:12 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "WillyWonka  , 18-Apr-07 22:50:12 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "WillyWonka  , 18-Apr-07 22:50:12",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "WillyWonka  ,  18-apr-07   22:50:12",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Mon, 18-Apr-1977 22:50:13 GMT",
-    "expected": "Mon, 18 Apr 1977 22:50:13 GMT"
-  }, {
-    "test": "Mon, 18-Apr-77 22:50:13 GMT",
-    "expected": "Mon, 18 Apr 1977 22:50:13 GMT"
-  }, {
-    "test": "\"Sat, 15-Apr-17\\\"21:01:22\\\"GMT\"",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Partyday, 18- April-07 22:50:12",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Partyday, 18 - Apri-07 22:50:12",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Wednes, 1-Januar-2003 00:00:00 GMT",
-    "expected": "Wed, 01 Jan 2003 00:00:00 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 GMT-2",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 GMT BLAH",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 GMT-0400",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 GMT-0400 (EDT)",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 DST",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 -0400",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 (hello there)",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 11:22:33",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 ::00 21:01:22",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 boink:z 21:01:22",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 91:22:33 21:01:22",
-    "expected": null
-  }, {
-    "test": "Thu Apr 18 22:50:12 2007 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "22:50:12 Thu Apr 18 2007 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Thu 22:50:12 Apr 18 2007 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Thu Apr 22:50:12 18 2007 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Thu Apr 18 22:50:12 2007 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Thu Apr 18 2007 22:50:12 GMT",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Thu Apr 18 2007 GMT 22:50:12",
-    "expected": "Wed, 18 Apr 2007 22:50:12 GMT"
-  }, {
-    "test": "Sat, 15-Apr-17 21:01:22 GMT",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "15-Sat, Apr-17 21:01:22 GMT",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "15-Sat, Apr 21:01:22 GMT 17",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "15-Sat, Apr 21:01:22 GMT 2017",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "15 Apr 21:01:22 2017",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "15 17 Apr 21:01:22",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Apr 15 17 21:01:22",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "Apr 15 21:01:22 17",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "2017 April 15 21:01:22",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "15 April 2017 21:01:22",
-    "expected": "Sat, 15 Apr 2017 21:01:22 GMT"
-  }, {
-    "test": "98 April 17 21:01:22",
-    "expected": null
-  }, {
-    "test": "Thu, 012-Aug-2008 20:49:07 GMT",
-    "expected": null
-  }, {
-    "test": "Thu, 12-Aug-31841 20:49:07 GMT",
-    "expected": null
-  }, {
-    "test": "Thu, 12-Aug-9999999999 20:49:07 GMT",
-    "expected": null
-  }, {
-    "test": "Thu, 999999999999-Aug-2007 20:49:07 GMT",
-    "expected": null
-  }, {
-    "test": "Thu, 12-Aug-2007 20:61:99999999999 GMT",
-    "expected": null
-  }, {
-    "test": "IAintNoDateFool",
-    "expected": null
-  }
+    test: 'Sat, 15-Apr-17 21:01:22 GMT',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Thu, 19-Apr-2007 16:00:00 GMT',
+    expected: 'Thu, 19 Apr 2007 16:00:00 GMT',
+  },
+  {
+    test: 'Wed, 25 Apr 2007 21:02:13 GMT',
+    expected: 'Wed, 25 Apr 2007 21:02:13 GMT',
+  },
+  {
+    test: 'Thu, 19/Apr\\2007 16:00:00 GMT',
+    expected: 'Thu, 19 Apr 2007 16:00:00 GMT',
+  },
+  {
+    test: 'Fri, 1 Jan 2010 01:01:50 GMT',
+    expected: 'Fri, 01 Jan 2010 01:01:50 GMT',
+  },
+  {
+    test: 'Wednesday, 1-Jan-2003 00:00:00 GMT',
+    expected: 'Wed, 01 Jan 2003 00:00:00 GMT',
+  },
+  {
+    test: ', 1-Jan-2003 00:00:00 GMT',
+    expected: 'Wed, 01 Jan 2003 00:00:00 GMT',
+  },
+  {
+    test: ' 1-Jan-2003 00:00:00 GMT',
+    expected: 'Wed, 01 Jan 2003 00:00:00 GMT',
+  },
+  {
+    test: '1-Jan-2003 00:00:00 GMT',
+    expected: 'Wed, 01 Jan 2003 00:00:00 GMT',
+  },
+  {
+    test: 'Wed,18-Apr-07 22:50:12 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'WillyWonka  , 18-Apr-07 22:50:12 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'WillyWonka  , 18-Apr-07 22:50:12',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'WillyWonka  ,  18-apr-07   22:50:12',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Mon, 18-Apr-1977 22:50:13 GMT',
+    expected: 'Mon, 18 Apr 1977 22:50:13 GMT',
+  },
+  {
+    test: 'Mon, 18-Apr-77 22:50:13 GMT',
+    expected: 'Mon, 18 Apr 1977 22:50:13 GMT',
+  },
+  {
+    test: '"Sat, 15-Apr-17\\"21:01:22\\"GMT"',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Partyday, 18- April-07 22:50:12',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Partyday, 18 - Apri-07 22:50:12',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Wednes, 1-Januar-2003 00:00:00 GMT',
+    expected: 'Wed, 01 Jan 2003 00:00:00 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 GMT-2',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 GMT BLAH',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 GMT-0400',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 GMT-0400 (EDT)',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 DST',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 -0400',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 (hello there)',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 11:22:33',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 ::00 21:01:22',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 boink:z 21:01:22',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 91:22:33 21:01:22',
+    expected: null,
+  },
+  {
+    test: 'Thu Apr 18 22:50:12 2007 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: '22:50:12 Thu Apr 18 2007 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Thu 22:50:12 Apr 18 2007 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Thu Apr 22:50:12 18 2007 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Thu Apr 18 22:50:12 2007 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Thu Apr 18 2007 22:50:12 GMT',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Thu Apr 18 2007 GMT 22:50:12',
+    expected: 'Wed, 18 Apr 2007 22:50:12 GMT',
+  },
+  {
+    test: 'Sat, 15-Apr-17 21:01:22 GMT',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '15-Sat, Apr-17 21:01:22 GMT',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '15-Sat, Apr 21:01:22 GMT 17',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '15-Sat, Apr 21:01:22 GMT 2017',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '15 Apr 21:01:22 2017',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '15 17 Apr 21:01:22',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Apr 15 17 21:01:22',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: 'Apr 15 21:01:22 17',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '2017 April 15 21:01:22',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '15 April 2017 21:01:22',
+    expected: 'Sat, 15 Apr 2017 21:01:22 GMT',
+  },
+  {
+    test: '98 April 17 21:01:22',
+    expected: null,
+  },
+  {
+    test: 'Thu, 012-Aug-2008 20:49:07 GMT',
+    expected: null,
+  },
+  {
+    test: 'Thu, 12-Aug-31841 20:49:07 GMT',
+    expected: null,
+  },
+  {
+    test: 'Thu, 12-Aug-9999999999 20:49:07 GMT',
+    expected: null,
+  },
+  {
+    test: 'Thu, 999999999999-Aug-2007 20:49:07 GMT',
+    expected: null,
+  },
+  {
+    test: 'Thu, 12-Aug-2007 20:61:99999999999 GMT',
+    expected: null,
+  },
+  {
+    test: 'IAintNoDateFool',
+    expected: null,
+  },
 ]

--- a/lib/__tests__/data/dates/examples.ts
+++ b/lib/__tests__/data/dates/examples.ts
@@ -1,48 +1,62 @@
 export default [
   {
-    "test": "Mon, 10-Dec-2007 17:02:24 GMT",
-    "expected": "Mon, 10 Dec 2007 17:02:24 GMT"
-  }, {
-    "test": "Wed, 09 Dec 2009 16:27:23 GMT",
-    "expected": "Wed, 09 Dec 2009 16:27:23 GMT"
-  }, {
-    "test": "Thursday, 01-Jan-1970 00:00:00 GMT",
-    "expected": "Thu, 01 Jan 1970 00:00:00 GMT"
-  }, {
-    "test": "Mon Dec 10 16:32:30 2007 GMT",
-    "expected": "Mon, 10 Dec 2007 16:32:30 GMT"
-  }, {
-    "test": "Wednesday, 01-Jan-10 00:00:00 GMT",
-    "expected": "Fri, 01 Jan 2010 00:00:00 GMT"
-  }, {
-    "test": "Mon, 10-Dec-07 20:35:03 GMT",
-    "expected": "Mon, 10 Dec 2007 20:35:03 GMT"
-  }, {
-    "test": "Wed, 1 Jan 2020 00:00:00 GMT",
-    "expected": "Wed, 01 Jan 2020 00:00:00 GMT"
-  }, {
-    "test": "Saturday, 8-Dec-2012 21:24:09 GMT",
-    "expected": "Sat, 08 Dec 2012 21:24:09 GMT"
-  }, {
-    "test": "Thu, 31 Dec 23:55:55 2037 GMT",
-    "expected": "Thu, 31 Dec 2037 23:55:55 GMT"
-  }, {
-    "test": "Sun,  9 Dec 2012 13:42:05 GMT",
-    "expected": "Sun, 09 Dec 2012 13:42:05 GMT"
-  }, {
-    "test": "Wed Dec 12 2007 08:44:07 GMT-0500 (EST)",
-    "expected": "Wed, 12 Dec 2007 08:44:07 GMT"
-  }, {
-    "test": "Mon, 01-Jan-2011 00: 00:00 GMT",
-    "expected": null
-  }, {
-    "test": "Sun, 1-Jan-1995 00:00:00 GMT",
-    "expected": "Sun, 01 Jan 1995 00:00:00 GMT"
-  }, {
-    "test": "Wednesday, 01-Jan-10 0:0:00 GMT",
-    "expected": "Fri, 01 Jan 2010 00:00:00 GMT"
-  }, {
-    "test": "Thu, 10 Dec 2009 13:57:2 GMT",
-    "expected": "Thu, 10 Dec 2009 13:57:02 GMT"
-  }
+    test: 'Mon, 10-Dec-2007 17:02:24 GMT',
+    expected: 'Mon, 10 Dec 2007 17:02:24 GMT',
+  },
+  {
+    test: 'Wed, 09 Dec 2009 16:27:23 GMT',
+    expected: 'Wed, 09 Dec 2009 16:27:23 GMT',
+  },
+  {
+    test: 'Thursday, 01-Jan-1970 00:00:00 GMT',
+    expected: 'Thu, 01 Jan 1970 00:00:00 GMT',
+  },
+  {
+    test: 'Mon Dec 10 16:32:30 2007 GMT',
+    expected: 'Mon, 10 Dec 2007 16:32:30 GMT',
+  },
+  {
+    test: 'Wednesday, 01-Jan-10 00:00:00 GMT',
+    expected: 'Fri, 01 Jan 2010 00:00:00 GMT',
+  },
+  {
+    test: 'Mon, 10-Dec-07 20:35:03 GMT',
+    expected: 'Mon, 10 Dec 2007 20:35:03 GMT',
+  },
+  {
+    test: 'Wed, 1 Jan 2020 00:00:00 GMT',
+    expected: 'Wed, 01 Jan 2020 00:00:00 GMT',
+  },
+  {
+    test: 'Saturday, 8-Dec-2012 21:24:09 GMT',
+    expected: 'Sat, 08 Dec 2012 21:24:09 GMT',
+  },
+  {
+    test: 'Thu, 31 Dec 23:55:55 2037 GMT',
+    expected: 'Thu, 31 Dec 2037 23:55:55 GMT',
+  },
+  {
+    test: 'Sun,  9 Dec 2012 13:42:05 GMT',
+    expected: 'Sun, 09 Dec 2012 13:42:05 GMT',
+  },
+  {
+    test: 'Wed Dec 12 2007 08:44:07 GMT-0500 (EST)',
+    expected: 'Wed, 12 Dec 2007 08:44:07 GMT',
+  },
+  {
+    test: 'Mon, 01-Jan-2011 00: 00:00 GMT',
+    expected: null,
+  },
+  {
+    test: 'Sun, 1-Jan-1995 00:00:00 GMT',
+    expected: 'Sun, 01 Jan 1995 00:00:00 GMT',
+  },
+  {
+    test: 'Wednesday, 01-Jan-10 0:0:00 GMT',
+    expected: 'Fri, 01 Jan 2010 00:00:00 GMT',
+  },
+  {
+    test: 'Thu, 10 Dec 2009 13:57:2 GMT',
+    expected: 'Thu, 10 Dec 2009 13:57:02 GMT',
+  },
 ]

--- a/lib/__tests__/data/parser.ts
+++ b/lib/__tests__/data/parser.ts
@@ -1,1959 +1,1333 @@
 export default [
   {
-    "test": "0001",
-    "received": [
-      "foo=bar"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0001',
+    received: ['foo=bar'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0002",
-    "received": [
-      "foo=bar; Expires=Fri, 07 Aug 9999 08:04:19 GMT"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0002',
+    received: ['foo=bar; Expires=Fri, 07 Aug 9999 08:04:19 GMT'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0003",
-    "received": [
-      "foo=bar; Expires=Fri, 07 Aug 2007 08:04:19 GMT",
-      "foo2=bar2; Expires=Fri, 07 Aug 9999 08:04:19 GMT"
+    test: '0003',
+    received: [
+      'foo=bar; Expires=Fri, 07 Aug 2007 08:04:19 GMT',
+      'foo2=bar2; Expires=Fri, 07 Aug 9999 08:04:19 GMT',
     ],
-    "sent": [
-      { "name": "foo2", "value": "bar2" }
-    ]
+    sent: [{ name: 'foo2', value: 'bar2' }],
   },
   {
-    "test": "0004",
-    "received": [
-      "foo"
-    ],
-    "sent": []
+    test: '0004',
+    received: ['foo'],
+    sent: [],
   },
   {
-    "test": "0005",
-    "received": [
-      "foo=bar; max-age=10000;"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0005',
+    received: ['foo=bar; max-age=10000;'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0006",
-    "received": [
-      "foo=bar; max-age=0;"
-    ],
-    "sent": []
+    test: '0006',
+    received: ['foo=bar; max-age=0;'],
+    sent: [],
   },
   {
-    "test": "0007",
-    "received": [
-      "foo=bar; version=1;"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0007',
+    received: ['foo=bar; version=1;'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0008",
-    "received": [
-      "foo=bar; version=1000;"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0008',
+    received: ['foo=bar; version=1000;'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0009",
-    "received": [
-      "foo=bar; customvalue=1000;"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0009',
+    received: ['foo=bar; customvalue=1000;'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0010",
-    "received": [
-      "foo=bar; secure;"
-    ],
-    "sent": []
+    test: '0010',
+    received: ['foo=bar; secure;'],
+    sent: [],
   },
   {
-    "test": "0011",
-    "received": [
-      "foo=bar; customvalue=\"1000 or more\";"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0011',
+    received: ['foo=bar; customvalue="1000 or more";'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0012",
-    "received": [
-      "foo=bar; customvalue=\"no trailing semicolon\""
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: '0012',
+    received: ['foo=bar; customvalue="no trailing semicolon"'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "0013",
-    "received": [
-      "foo=bar",
-      "foo=qux"
-    ],
-    "sent": [
-      { "name": "foo", "value": "qux" }
-    ]
+    test: '0013',
+    received: ['foo=bar', 'foo=qux'],
+    sent: [{ name: 'foo', value: 'qux' }],
   },
   {
-    "test": "0014",
-    "received": [
-      "foo1=bar",
-      "foo2=qux"
+    test: '0014',
+    received: ['foo1=bar', 'foo2=qux'],
+    sent: [
+      { name: 'foo1', value: 'bar' },
+      { name: 'foo2', value: 'qux' },
     ],
-    "sent": [
-      { "name": "foo1", "value": "bar" },
-      { "name": "foo2", "value": "qux" }
-    ]
   },
   {
-    "test": "0015",
-    "received": [
-      "a=b",
-      "z=y"
+    test: '0015',
+    received: ['a=b', 'z=y'],
+    sent: [
+      { name: 'a', value: 'b' },
+      { name: 'z', value: 'y' },
     ],
-    "sent": [
-      { "name": "a", "value": "b" },
-      { "name": "z", "value": "y" }
-    ]
   },
   {
-    "test": "0016",
-    "received": [
-      "z=y",
-      "a=b"
+    test: '0016',
+    received: ['z=y', 'a=b'],
+    sent: [
+      { name: 'z', value: 'y' },
+      { name: 'a', value: 'b' },
     ],
-    "sent": [
-      { "name": "z", "value": "y" },
-      { "name": "a", "value": "b" }
-    ]
   },
   {
-    "test": "0017",
-    "received": [
-      "z=y, a=b"
-    ],
-    "sent": [
-      { "name": "z", "value": "y, a=b" }
-    ]
+    test: '0017',
+    received: ['z=y, a=b'],
+    sent: [{ name: 'z', value: 'y, a=b' }],
   },
   {
-    "test": "0018",
-    "received": [
-      "z=y; foo=bar, a=b"
-    ],
-    "sent": [
-      { "name": "z", "value": "y" }
-    ]
+    test: '0018',
+    received: ['z=y; foo=bar, a=b'],
+    sent: [{ name: 'z', value: 'y' }],
   },
   {
-    "test": "0019",
-    "received": [
-      "foo=b;max-age=3600, c=d;path=/"
-    ],
-    "sent": [
-      { "name": "foo", "value": "b" }
-    ]
+    test: '0019',
+    received: ['foo=b;max-age=3600, c=d;path=/'],
+    sent: [{ name: 'foo', value: 'b' }],
   },
   {
-    "test": "0020",
-    "received": [
-      "a=b",
-      "=",
-      "c=d"
+    test: '0020',
+    received: ['a=b', '=', 'c=d'],
+    sent: [
+      { name: 'a', value: 'b' },
+      { name: 'c', value: 'd' },
     ],
-    "sent": [
-      { "name": "a", "value": "b" },
-      { "name": "c", "value": "d" }
-    ]
   },
   {
-    "test": "0021",
-    "received": [
-      "a=b",
-      "=x",
-      "c=d"
+    test: '0021',
+    received: ['a=b', '=x', 'c=d'],
+    sent: [
+      { name: 'a', value: 'b' },
+      { name: 'c', value: 'd' },
     ],
-    "sent": [
-      { "name": "a", "value": "b" },
-      { "name": "c", "value": "d" }
-    ]
   },
   {
-    "test": "0022",
-    "received": [
-      "a=b",
-      "x=",
-      "c=d"
+    test: '0022',
+    received: ['a=b', 'x=', 'c=d'],
+    sent: [
+      { name: 'a', value: 'b' },
+      { name: 'x', value: '' },
+      { name: 'c', value: 'd' },
     ],
-    "sent": [
-      { "name": "a", "value": "b" },
-      { "name": "x", "value": "" },
-      { "name": "c", "value": "d" }
-    ]
   },
   {
-    "test": "0023",
-    "received": [
-      "foo",
-      ""
-    ],
-    "sent": []
+    test: '0023',
+    received: ['foo', ''],
+    sent: [],
   },
   {
-    "test": "0024",
-    "received": [
-      "foo",
-      "="
-    ],
-    "sent": []
+    test: '0024',
+    received: ['foo', '='],
+    sent: [],
   },
   {
-    "test": "0025",
-    "received": [
-      "foo",
-      "; bar"
-    ],
-    "sent": []
+    test: '0025',
+    received: ['foo', '; bar'],
+    sent: [],
   },
   {
-    "test": "0026",
-    "received": [
-      "foo",
-      "   "
-    ],
-    "sent": []
+    test: '0026',
+    received: ['foo', '   '],
+    sent: [],
   },
   {
-    "test": "0027",
-    "received": [
-      "foo",
-      "bar"
-    ],
-    "sent": []
+    test: '0027',
+    received: ['foo', 'bar'],
+    sent: [],
   },
   {
-    "test": "0028",
-    "received": [
-      "foo",
-      "\t"
-    ],
-    "sent": []
+    test: '0028',
+    received: ['foo', '\t'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0001",
-    "received": [
-      "foo=bar; Secure"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0001',
+    received: ['foo=bar; Secure'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0002",
-    "received": [
-      "foo=bar; seCURe"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0002',
+    received: ['foo=bar; seCURe'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0003",
-    "received": [
-      "foo=bar; \"Secure\""
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'ATTRIBUTE0003',
+    received: ['foo=bar; "Secure"'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "ATTRIBUTE0004",
-    "received": [
-      "foo=bar; Secure="
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0004',
+    received: ['foo=bar; Secure='],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0005",
-    "received": [
-      "foo=bar; Secure=aaaa"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0005',
+    received: ['foo=bar; Secure=aaaa'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0006",
-    "received": [
-      "foo=bar; Secure qux"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'ATTRIBUTE0006',
+    received: ['foo=bar; Secure qux'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "ATTRIBUTE0007",
-    "received": [
-      "foo=bar; Secure =aaaaa"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0007',
+    received: ['foo=bar; Secure =aaaaa'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0008",
-    "received": [
-      "foo=bar; Secure= aaaaa"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0008',
+    received: ['foo=bar; Secure= aaaaa'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0009",
-    "received": [
-      "foo=bar; Secure; qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0009',
+    received: ['foo=bar; Secure; qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0010",
-    "received": [
-      "foo=bar; Secure;qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0010',
+    received: ['foo=bar; Secure;qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0011",
-    "received": [
-      "foo=bar; Secure    ; qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0011',
+    received: ['foo=bar; Secure    ; qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0012",
-    "received": [
-      "foo=bar;                Secure"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0012',
+    received: ['foo=bar;                Secure'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0013",
-    "received": [
-      "foo=bar;       Secure     ;"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0013',
+    received: ['foo=bar;       Secure     ;'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0014",
-    "received": [
-      "foo=bar; Path"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'ATTRIBUTE0014',
+    received: ['foo=bar; Path'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "ATTRIBUTE0015",
-    "received": [
-      "foo=bar; Path="
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'ATTRIBUTE0015',
+    received: ['foo=bar; Path='],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "ATTRIBUTE0016",
-    "received": [
-      "foo=bar; Path=/"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'ATTRIBUTE0016',
+    received: ['foo=bar; Path=/'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "ATTRIBUTE0017",
-    "received": [
-      "foo=bar; Path=/qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0017',
+    received: ['foo=bar; Path=/qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0018",
-    "received": [
-      "foo=bar; Path    =/qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0018',
+    received: ['foo=bar; Path    =/qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0019",
-    "received": [
-      "foo=bar; Path=    /qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0019',
+    received: ['foo=bar; Path=    /qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0020",
-    "received": [
-      "foo=bar; Path=/qux      ; taz"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0020',
+    received: ['foo=bar; Path=/qux      ; taz'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0021",
-    "received": [
-      "foo=bar; Path=/qux; Path=/"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'ATTRIBUTE0021',
+    received: ['foo=bar; Path=/qux; Path=/'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "ATTRIBUTE0022",
-    "received": [
-      "foo=bar; Path=/; Path=/qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0022',
+    received: ['foo=bar; Path=/; Path=/qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0023",
-    "received": [
-      "foo=bar; Path=/qux; Path=/cookie-parser-result"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'ATTRIBUTE0023',
+    received: ['foo=bar; Path=/qux; Path=/cookie-parser-result'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "ATTRIBUTE0024",
-    "received": [
-      "foo=bar; Path=/cookie-parser-result; Path=/qux"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0024',
+    received: ['foo=bar; Path=/cookie-parser-result; Path=/qux'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0025",
-    "received": [
-      "foo=bar; qux; Secure"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0025',
+    received: ['foo=bar; qux; Secure'],
+    sent: [],
   },
   {
-    "test": "ATTRIBUTE0026",
-    "received": [
-      "foo=bar; qux=\"aaa;bbb\"; Secure"
-    ],
-    "sent": []
+    test: 'ATTRIBUTE0026',
+    received: ['foo=bar; qux="aaa;bbb"; Secure'],
+    sent: [],
   },
   {
-    "test": "CHARSET0001",
-    "received": [
-      "foo=\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c"
+    test: 'CHARSET0001',
+    received: [
+      'foo=\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c',
+    ],
+    sent: [
+      {
+        name: 'foo',
+        value:
+          '\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c',
+      },
     ],
-    "sent": [
-      { "name": "foo", "value": "\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c" }
-    ]
   },
   {
-    "test": "CHARSET0002",
-    "received": [
-      "\u6625\u8282\u56de=\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c"
+    test: 'CHARSET0002',
+    received: [
+      '\u6625\u8282\u56de=\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c',
     ],
-    "sent": [
-      { "name": "\u6625\u8282\u56de", "value": "\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c" }
-    ]
+    sent: [
+      {
+        name: '\u6625\u8282\u56de',
+        value: '\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c',
+      },
+    ],
   },
   {
-    "test": "CHARSET0003",
-    "received": [
-      "\u6625\u8282\u56de=\u5bb6\u8def\u00b7\u6625\u8fd0; \u5b8c\u5168\u624b\u518c"
+    test: 'CHARSET0003',
+    received: [
+      '\u6625\u8282\u56de=\u5bb6\u8def\u00b7\u6625\u8fd0; \u5b8c\u5168\u624b\u518c',
+    ],
+    sent: [
+      { name: '\u6625\u8282\u56de', value: '\u5bb6\u8def\u00b7\u6625\u8fd0' },
     ],
-    "sent": [
-      { "name": "\u6625\u8282\u56de", "value": "\u5bb6\u8def\u00b7\u6625\u8fd0" }
-    ]
   },
   {
-    "test": "CHARSET0004",
-    "received": [
-      "foo=\"\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c\""
+    test: 'CHARSET0004',
+    received: [
+      'foo="\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c"',
     ],
-    "sent": [
-      { "name": "foo", "value": "\"\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c\"" }
-    ]
+    sent: [
+      {
+        name: 'foo',
+        value:
+          '"\u6625\u8282\u56de\u5bb6\u8def\u00b7\u6625\u8fd0\u5b8c\u5168\u624b\u518c"',
+      },
+    ],
   },
   {
-    "test": "CHROMIUM0001",
-    "received": [
-      "a=b"
-    ],
-    "sent": [
-      { "name": "a", "value": "b" }
-    ]
+    test: 'CHROMIUM0001',
+    received: ['a=b'],
+    sent: [{ name: 'a', value: 'b' }],
   },
   {
-    "test": "CHROMIUM0002",
-    "received": [
-      "aBc=\"zzz \"   ;"
-    ],
-    "sent": [
-      { "name": "aBc", "value": "\"zzz \"" }
-    ]
+    test: 'CHROMIUM0002',
+    received: ['aBc="zzz "   ;'],
+    sent: [{ name: 'aBc', value: '"zzz "' }],
   },
   {
-    "test": "CHROMIUM0003",
-    "received": [
-      "aBc=\"zzz \" ;"
-    ],
-    "sent": [
-      { "name": "aBc", "value": "\"zzz \"" }
-    ]
+    test: 'CHROMIUM0003',
+    received: ['aBc="zzz " ;'],
+    sent: [{ name: 'aBc', value: '"zzz "' }],
   },
   {
-    "test": "CHROMIUM0004",
-    "received": [
-      "aBc=\"zz;pp\" ; ;"
-    ],
-    "sent": [
-      { "name": "aBc", "value": "\"zz" }
-    ]
+    test: 'CHROMIUM0004',
+    received: ['aBc="zz;pp" ; ;'],
+    sent: [{ name: 'aBc', value: '"zz' }],
   },
   {
-    "test": "CHROMIUM0005",
-    "received": [
-      "aBc=\"zz ;"
-    ],
-    "sent": [
-      { "name": "aBc", "value": "\"zz" }
-    ]
+    test: 'CHROMIUM0005',
+    received: ['aBc="zz ;'],
+    sent: [{ name: 'aBc', value: '"zz' }],
   },
   {
-    "test": "CHROMIUM0006",
-    "received": [
-      "aBc=\"zzz \"   \"ppp\"  ;"
-    ],
-    "sent": [
-      { "name": "aBc", "value": "\"zzz \"   \"ppp\"" }
-    ]
+    test: 'CHROMIUM0006',
+    received: ['aBc="zzz "   "ppp"  ;'],
+    sent: [{ name: 'aBc', value: '"zzz "   "ppp"' }],
   },
   {
-    "test": "CHROMIUM0007",
-    "received": [
-      "aBc=\"zzz \"   \"ppp\" ;"
-    ],
-    "sent": [
-      { "name": "aBc", "value": "\"zzz \"   \"ppp\"" }
-    ]
+    test: 'CHROMIUM0007',
+    received: ['aBc="zzz "   "ppp" ;'],
+    sent: [{ name: 'aBc', value: '"zzz "   "ppp"' }],
   },
   {
-    "test": "CHROMIUM0008",
-    "received": [
-      "aBc=A\"B ;"
-    ],
-    "sent": [
-      { "name": "aBc", "value": "A\"B" }
-    ]
+    test: 'CHROMIUM0008',
+    received: ['aBc=A"B ;'],
+    sent: [{ name: 'aBc', value: 'A"B' }],
   },
   {
-    "test": "CHROMIUM0009",
-    "received": [
-      "BLAHHH; path=/;"
-    ],
-    "sent": []
+    test: 'CHROMIUM0009',
+    received: ['BLAHHH; path=/;'],
+    sent: [],
   },
   {
-    "test": "CHROMIUM0010",
-    "received": [
-      "\"BLA\\\"HHH\"; path=/;"
-    ],
-    "sent": []
+    test: 'CHROMIUM0010',
+    received: ['"BLA\\"HHH"; path=/;'],
+    sent: [],
   },
   {
-    "test": "CHROMIUM0011",
-    "received": [
-      "a=\"B"
-    ],
-    "sent": [
-      { "name": "a", "value": "\"B" }
-    ]
+    test: 'CHROMIUM0011',
+    received: ['a="B'],
+    sent: [{ name: 'a', value: '"B' }],
   },
   {
-    "test": "CHROMIUM0012",
-    "received": [
-      "=ABC"
-    ],
-    "sent": []
+    test: 'CHROMIUM0012',
+    received: ['=ABC'],
+    sent: [],
   },
   {
-    "test": "CHROMIUM0013",
-    "received": [
-      "ABC=;  path = /"
-    ],
-    "sent": [
-      { "name": "ABC", "value": "" }
-    ]
+    test: 'CHROMIUM0013',
+    received: ['ABC=;  path = /'],
+    sent: [{ name: 'ABC', value: '' }],
   },
   {
-    "test": "CHROMIUM0014",
-    "received": [
-      "  A  = BC  ;foo;;;   bar"
-    ],
-    "sent": [
-      { "name": "A", "value": "BC" }
-    ]
+    test: 'CHROMIUM0014',
+    received: ['  A  = BC  ;foo;;;   bar'],
+    sent: [{ name: 'A', value: 'BC' }],
   },
   {
-    "test": "CHROMIUM0015",
-    "received": [
-      "  A=== BC  ;foo;;;   bar"
-    ],
-    "sent": [
-      { "name": "A", "value": "== BC" }
-    ]
+    test: 'CHROMIUM0015',
+    received: ['  A=== BC  ;foo;;;   bar'],
+    sent: [{ name: 'A', value: '== BC' }],
   },
   {
-    "test": "CHROMIUM0016",
-    "received": [
-      "foo=\"zohNumRKgI0oxyhSsV3Z7D\"  ; expires=Sun, 18-Apr-2027 21:06:29 GMT ; path=/  ;  "
+    test: 'CHROMIUM0016',
+    received: [
+      'foo="zohNumRKgI0oxyhSsV3Z7D"  ; expires=Sun, 18-Apr-2027 21:06:29 GMT ; path=/  ;  ',
     ],
-    "sent": [
-      { "name": "foo", "value": "\"zohNumRKgI0oxyhSsV3Z7D\"" }
-    ]
+    sent: [{ name: 'foo', value: '"zohNumRKgI0oxyhSsV3Z7D"' }],
   },
   {
-    "test": "CHROMIUM0017",
-    "received": [
-      "foo=zohNumRKgI0oxyhSsV3Z7D  ; expires=Sun, 18-Apr-2027 21:06:29 GMT ; path=/  ;  "
+    test: 'CHROMIUM0017',
+    received: [
+      'foo=zohNumRKgI0oxyhSsV3Z7D  ; expires=Sun, 18-Apr-2027 21:06:29 GMT ; path=/  ;  ',
     ],
-    "sent": [
-      { "name": "foo", "value": "zohNumRKgI0oxyhSsV3Z7D" }
-    ]
+    sent: [{ name: 'foo', value: 'zohNumRKgI0oxyhSsV3Z7D' }],
   },
   {
-    "test": "CHROMIUM0018",
-    "received": [
-      "    "
-    ],
-    "sent": []
+    test: 'CHROMIUM0018',
+    received: ['    '],
+    sent: [],
   },
   {
-    "test": "CHROMIUM0019",
-    "received": [
-      "a=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    test: 'CHROMIUM0019',
+    received: [
+      'a=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    ],
+    sent: [
+      {
+        name: 'a',
+        value:
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
     ],
-    "sent": [
-      { "name": "a", "value": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
-    ]
   },
   {
-    "test": "CHROMIUM0021",
-    "received": [
-      ""
-    ],
-    "sent": []
+    test: 'CHROMIUM0021',
+    received: [''],
+    sent: [],
   },
   {
-    "test": "COMMA0001",
-    "received": [
-      "foo=bar, baz=qux"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar, baz=qux" }
-    ]
+    test: 'COMMA0001',
+    received: ['foo=bar, baz=qux'],
+    sent: [{ name: 'foo', value: 'bar, baz=qux' }],
   },
   {
-    "test": "COMMA0002",
-    "received": [
-      "foo=\"bar, baz=qux\""
-    ],
-    "sent": [
-      { "name": "foo", "value": "\"bar, baz=qux\"" }
-    ]
+    test: 'COMMA0002',
+    received: ['foo="bar, baz=qux"'],
+    sent: [{ name: 'foo', value: '"bar, baz=qux"' }],
   },
   {
-    "test": "COMMA0003",
-    "received": [
-      "foo=bar; b,az=qux"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'COMMA0003',
+    received: ['foo=bar; b,az=qux'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "COMMA0004",
-    "received": [
-      "foo=bar; baz=q,ux"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'COMMA0004',
+    received: ['foo=bar; baz=q,ux'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "COMMA0005",
-    "received": [
-      "foo=bar; Max-Age=50,399"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'COMMA0005',
+    received: ['foo=bar; Max-Age=50,399'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "COMMA0006",
-    "received": [
-      "foo=bar; Expires=Fri, 07 Aug 9999 08:04:19 GMT"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'COMMA0006',
+    received: ['foo=bar; Expires=Fri, 07 Aug 9999 08:04:19 GMT'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "COMMA0007",
-    "received": [
-      "foo=bar; Expires=Fri 07 Aug 9999 08:04:19 GMT, baz=qux"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'COMMA0007',
+    received: ['foo=bar; Expires=Fri 07 Aug 9999 08:04:19 GMT, baz=qux'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DISABLED_CHROMIUM0020",
-    "received": [
-      "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    test: 'DISABLED_CHROMIUM0020',
+    received: [
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     ],
-    "sent": []
+    sent: [],
   },
   {
-    "test": "DISABLED_CHROMIUM0022",
-    "received": [
-      "AAA=BB\u0000ZYX"
-    ],
-    "sent": [
-      { "name": "AAA", "value": "BB" }
-    ]
+    test: 'DISABLED_CHROMIUM0022',
+    received: ['AAA=BB\u0000ZYX'],
+    sent: [{ name: 'AAA', value: 'BB' }],
   },
   {
-    "test": "DISABLED_CHROMIUM0023",
-    "received": [
-      "AAA=BB\rZYX"
-    ],
-    "sent": [
-      { "name": "AAA", "value": "BB" }
-    ]
+    test: 'DISABLED_CHROMIUM0023',
+    received: ['AAA=BB\rZYX'],
+    sent: [{ name: 'AAA', value: 'BB' }],
   },
   {
-    "test": "DISABLED_PATH0029",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/bar"
-    ],
-    "sent-to": "/cookie-parser-result/f%6Fo/bar?disabled-path0029",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DISABLED_PATH0029',
+    received: ['foo=bar; path=/cookie-parser-result/foo/bar'],
+    'sent-to': '/cookie-parser-result/f%6Fo/bar?disabled-path0029',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0001",
-    "received": [
-      "foo=bar; domain=home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0001",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0001',
+    received: ['foo=bar; domain=home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0001',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0002",
-    "received": [
-      "foo=bar; domain=home.example.org"
-    ],
-    "sent-to": "http://sibling.example.org:8888/cookie-parser-result?domain0002",
-    "sent": []
+    test: 'DOMAIN0002',
+    received: ['foo=bar; domain=home.example.org'],
+    'sent-to':
+      'http://sibling.example.org:8888/cookie-parser-result?domain0002',
+    sent: [],
   },
   {
-    "test": "DOMAIN0003",
-    "received": [
-      "foo=bar; domain=.home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0003",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0003',
+    received: ['foo=bar; domain=.home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0003',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0004",
-    "received": [
-      "foo=bar; domain=home.example.org"
-    ],
-    "sent-to": "http://subdomain.home.example.org:8888/cookie-parser-result?domain0004",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0004',
+    received: ['foo=bar; domain=home.example.org'],
+    'sent-to':
+      'http://subdomain.home.example.org:8888/cookie-parser-result?domain0004',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0005",
-    "received": [
-      "foo=bar; domain=.home.example.org"
-    ],
-    "sent-to": "http://subdomain.home.example.org:8888/cookie-parser-result?domain0005",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0005',
+    received: ['foo=bar; domain=.home.example.org'],
+    'sent-to':
+      'http://subdomain.home.example.org:8888/cookie-parser-result?domain0005',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0006",
-    "received": [
-      "foo=bar; domain=.home.example.org"
-    ],
-    "sent-to": "http://sibling.example.org:8888/cookie-parser-result?domain0006",
-    "sent": []
+    test: 'DOMAIN0006',
+    received: ['foo=bar; domain=.home.example.org'],
+    'sent-to':
+      'http://sibling.example.org:8888/cookie-parser-result?domain0006',
+    sent: [],
   },
   {
-    "test": "DOMAIN0007",
-    "received": [
-      "foo=bar; domain=sibling.example.org"
-    ],
-    "sent-to": "http://sibling.example.org:8888/cookie-parser-result?domain0007",
-    "sent": []
+    test: 'DOMAIN0007',
+    received: ['foo=bar; domain=sibling.example.org'],
+    'sent-to':
+      'http://sibling.example.org:8888/cookie-parser-result?domain0007',
+    sent: [],
   },
   {
-    "test": "DOMAIN0008",
-    "received": [
-      "foo=bar; domain=.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0008",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0008',
+    received: ['foo=bar; domain=.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0008',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0009",
-    "received": [
-      "foo=bar; domain=example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0009",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0009',
+    received: ['foo=bar; domain=example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0009',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0010",
-    "received": [
-      "foo=bar; domain=..home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0010",
-    "sent": []
+    test: 'DOMAIN0010',
+    received: ['foo=bar; domain=..home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0010',
+    sent: [],
   },
   {
-    "test": "DOMAIN0011",
-    "received": [
-      "foo=bar; domain=home..example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0011",
-    "sent": []
+    test: 'DOMAIN0011',
+    received: ['foo=bar; domain=home..example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0011',
+    sent: [],
   },
   {
-    "test": "DOMAIN0012",
-    "received": [
-      "foo=bar; domain=  .home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0012",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0012',
+    received: ['foo=bar; domain=  .home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0012',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0013",
-    "received": [
-      "foo=bar; domain=  .  home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0013",
-    "sent": []
+    test: 'DOMAIN0013',
+    received: ['foo=bar; domain=  .  home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0013',
+    sent: [],
   },
   {
-    "test": "DOMAIN0014",
-    "received": [
-      "foo=bar; domain=home.example.org."
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0014",
-    "sent": []
+    test: 'DOMAIN0014',
+    received: ['foo=bar; domain=home.example.org.'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0014',
+    sent: [],
   },
   {
-    "test": "DOMAIN0015",
-    "received": [
-      "foo=bar; domain=home.example.org.."
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0015",
-    "sent": []
+    test: 'DOMAIN0015',
+    received: ['foo=bar; domain=home.example.org..'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0015',
+    sent: [],
   },
   {
-    "test": "DOMAIN0016",
-    "received": [
-      "foo=bar; domain=home.example.org ."
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0016",
-    "sent": []
+    test: 'DOMAIN0016',
+    received: ['foo=bar; domain=home.example.org .'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0016',
+    sent: [],
   },
   {
-    "test": "DOMAIN0017",
-    "received": [
-      "foo=bar; domain=.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0017",
-    "sent": []
+    test: 'DOMAIN0017',
+    received: ['foo=bar; domain=.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0017',
+    sent: [],
   },
   {
-    "test": "DOMAIN0018",
-    "received": [
-      "foo=bar; domain=.org."
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0018",
-    "sent": []
+    test: 'DOMAIN0018',
+    received: ['foo=bar; domain=.org.'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0018',
+    sent: [],
   },
   {
-    "test": "DOMAIN0019",
-    "received": [
-      "foo=bar; domain=home.example.org",
-      "foo2=bar2; domain=.home.example.org"
+    test: 'DOMAIN0019',
+    received: [
+      'foo=bar; domain=home.example.org',
+      'foo2=bar2; domain=.home.example.org',
+    ],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0019',
+    sent: [
+      { name: 'foo', value: 'bar' },
+      { name: 'foo2', value: 'bar2' },
     ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0019",
-    "sent": [
-      { "name": "foo", "value": "bar" },
-      { "name": "foo2", "value": "bar2" }
-    ]
   },
   {
-    "test": "DOMAIN0020",
-    "received": [
-      "foo2=bar2; domain=.home.example.org",
-      "foo=bar; domain=home.example.org"
+    test: 'DOMAIN0020',
+    received: [
+      'foo2=bar2; domain=.home.example.org',
+      'foo=bar; domain=home.example.org',
     ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0020",
-    "sent": [
-      { "name": "foo2", "value": "bar2" },
-      { "name": "foo", "value": "bar" }
-    ]
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0020',
+    sent: [
+      { name: 'foo2', value: 'bar2' },
+      { name: 'foo', value: 'bar' },
+    ],
   },
   {
-    "test": "DOMAIN0021",
-    "received": [
-      "foo=bar; domain=\"home.example.org\""
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0021",
-    "sent": []
+    test: 'DOMAIN0021',
+    received: ['foo=bar; domain="home.example.org"'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0021',
+    sent: [],
   },
   {
-    "test": "DOMAIN0022",
-    "received": [
-      "foo=bar; domain=home.example.org",
-      "foo2=bar2; domain=.example.org"
+    test: 'DOMAIN0022',
+    received: [
+      'foo=bar; domain=home.example.org',
+      'foo2=bar2; domain=.example.org',
     ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0022",
-    "sent": [
-      { "name": "foo", "value": "bar" },
-      { "name": "foo2", "value": "bar2" }
-    ]
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0022',
+    sent: [
+      { name: 'foo', value: 'bar' },
+      { name: 'foo2', value: 'bar2' },
+    ],
   },
   {
-    "test": "DOMAIN0023",
-    "received": [
-      "foo2=bar2; domain=.example.org",
-      "foo=bar; domain=home.example.org"
+    test: 'DOMAIN0023',
+    received: [
+      'foo2=bar2; domain=.example.org',
+      'foo=bar; domain=home.example.org',
     ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0023",
-    "sent": [
-      { "name": "foo2", "value": "bar2" },
-      { "name": "foo", "value": "bar" }
-    ]
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0023',
+    sent: [
+      { name: 'foo2', value: 'bar2' },
+      { name: 'foo', value: 'bar' },
+    ],
   },
   {
-    "test": "DOMAIN0024",
-    "received": [
-      "foo=bar; domain=.example.org; domain=home.example.org"
-    ],
-    "sent-to": "http://sibling.example.org:8888/cookie-parser-result?domain0024",
-    "sent": []
+    test: 'DOMAIN0024',
+    received: ['foo=bar; domain=.example.org; domain=home.example.org'],
+    'sent-to':
+      'http://sibling.example.org:8888/cookie-parser-result?domain0024',
+    sent: [],
   },
   {
-    "test": "DOMAIN0025",
-    "received": [
-      "foo=bar; domain=home.example.org; domain=.example.org"
-    ],
-    "sent-to": "http://sibling.example.org:8888/cookie-parser-result?domain0025",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0025',
+    received: ['foo=bar; domain=home.example.org; domain=.example.org'],
+    'sent-to':
+      'http://sibling.example.org:8888/cookie-parser-result?domain0025',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0026",
-    "received": [
-      "foo=bar; domain=home.eXaMpLe.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0026",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0026',
+    received: ['foo=bar; domain=home.eXaMpLe.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0026',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0027",
-    "received": [
-      "foo=bar; domain=home.example.org:8888"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0027",
-    "sent": []
+    test: 'DOMAIN0027',
+    received: ['foo=bar; domain=home.example.org:8888'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0027',
+    sent: [],
   },
   {
-    "test": "DOMAIN0028",
-    "received": [
-      "foo=bar; domain=subdomain.home.example.org"
-    ],
-    "sent-to": "http://subdomain.home.example.org:8888/cookie-parser-result?domain0028",
-    "sent": []
+    test: 'DOMAIN0028',
+    received: ['foo=bar; domain=subdomain.home.example.org'],
+    'sent-to':
+      'http://subdomain.home.example.org:8888/cookie-parser-result?domain0028',
+    sent: [],
   },
   {
-    "test": "DOMAIN0029",
-    "received": [
-      "foo=bar"
-    ],
-    "sent-to": "http://subdomain.home.example.org:8888/cookie-parser-result?domain0029",
-    "sent": []
+    test: 'DOMAIN0029',
+    received: ['foo=bar'],
+    'sent-to':
+      'http://subdomain.home.example.org:8888/cookie-parser-result?domain0029',
+    sent: [],
   },
   {
-    "test": "DOMAIN0031",
-    "received": [
-      "foo=bar; domain=home.example.org; domain=.example.org"
-    ],
-    "sent-to": "http://sibling.example.org:8888/cookie-parser-result?domain0031",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0031',
+    received: ['foo=bar; domain=home.example.org; domain=.example.org'],
+    'sent-to':
+      'http://sibling.example.org:8888/cookie-parser-result?domain0031',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0033",
-    "received": [
-      "foo=bar; domain=home.example.org"
-    ],
-    "sent-to": "http://hoMe.eXaMplE.org:8888/cookie-parser-result?domain0033",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0033',
+    received: ['foo=bar; domain=home.example.org'],
+    'sent-to': 'http://hoMe.eXaMplE.org:8888/cookie-parser-result?domain0033',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0034",
-    "received": [
-      "foo=bar; domain=home.example.org; domain=home.example.com"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0034",
-    "sent": []
+    test: 'DOMAIN0034',
+    received: ['foo=bar; domain=home.example.org; domain=home.example.com'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0034',
+    sent: [],
   },
   {
-    "test": "DOMAIN0035",
-    "received": [
-      "foo=bar; domain=home.example.com; domain=home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0035",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0035',
+    received: ['foo=bar; domain=home.example.com; domain=home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0035',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0036",
-    "received": [
-      "foo=bar; domain=home.example.org; domain=home.example.com; domain=home.example.org"
+    test: 'DOMAIN0036',
+    received: [
+      'foo=bar; domain=home.example.org; domain=home.example.com; domain=home.example.org',
     ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0036",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0036',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0037",
-    "received": [
-      "foo=bar; domain=home.example.com; domain=home.example.org; domain=home.example.com"
+    test: 'DOMAIN0037',
+    received: [
+      'foo=bar; domain=home.example.com; domain=home.example.org; domain=home.example.com',
     ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0037",
-    "sent": []
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0037',
+    sent: [],
   },
   {
-    "test": "DOMAIN0038",
-    "received": [
-      "foo=bar; domain=home.example.org; domain=home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0038",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0038',
+    received: ['foo=bar; domain=home.example.org; domain=home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0038',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0039",
-    "received": [
-      "foo=bar; domain=home.example.org; domain=example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0039",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0039',
+    received: ['foo=bar; domain=home.example.org; domain=example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0039',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0040",
-    "received": [
-      "foo=bar; domain=example.org; domain=home.example.org"
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?domain0040",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'DOMAIN0040',
+    received: ['foo=bar; domain=example.org; domain=home.example.org'],
+    'sent-to': 'http://home.example.org:8888/cookie-parser-result?domain0040',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "DOMAIN0041",
-    "received": [
-      "foo=bar; domain=.sibling.example.org"
-    ],
-    "sent-to": "http://sibling.example.org:8888/cookie-parser-result?domain0041",
-    "sent": []
+    test: 'DOMAIN0041',
+    received: ['foo=bar; domain=.sibling.example.org'],
+    'sent-to':
+      'http://sibling.example.org:8888/cookie-parser-result?domain0041',
+    sent: [],
   },
   {
-    "test": "DOMAIN0042",
-    "received": [
-      "foo=bar; domain=.sibling.home.example.org"
-    ],
-    "sent-to": "http://sibling.home.example.org:8888/cookie-parser-result?domain0042",
-    "sent": []
+    test: 'DOMAIN0042',
+    received: ['foo=bar; domain=.sibling.home.example.org'],
+    'sent-to':
+      'http://sibling.home.example.org:8888/cookie-parser-result?domain0042',
+    sent: [],
   },
   {
-    "test": "MOZILLA0001",
-    "received": [
-      "foo=bar; max-age=-1"
-    ],
-    "sent": []
+    test: 'MOZILLA0001',
+    received: ['foo=bar; max-age=-1'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0002",
-    "received": [
-      "foo=bar; max-age=0"
-    ],
-    "sent": []
+    test: 'MOZILLA0002',
+    received: ['foo=bar; max-age=0'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0003",
-    "received": [
-      "foo=bar; expires=Thu, 10 Apr 1980 16:33:12 GMT"
-    ],
-    "sent": []
+    test: 'MOZILLA0003',
+    received: ['foo=bar; expires=Thu, 10 Apr 1980 16:33:12 GMT'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0004",
-    "received": [
-      "foo=bar; max-age=60"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'MOZILLA0004',
+    received: ['foo=bar; max-age=60'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "MOZILLA0005",
-    "received": [
-      "foo=bar; max-age=-20"
-    ],
-    "sent": []
+    test: 'MOZILLA0005',
+    received: ['foo=bar; max-age=-20'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0006",
-    "received": [
-      "foo=bar; max-age=60"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'MOZILLA0006',
+    received: ['foo=bar; max-age=60'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "MOZILLA0007",
-    "received": [
-      "foo=bar; expires=Thu, 10 Apr 1980 16:33:12 GMT"
-    ],
-    "sent": []
+    test: 'MOZILLA0007',
+    received: ['foo=bar; expires=Thu, 10 Apr 1980 16:33:12 GMT'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0008",
-    "received": [
-      "foo=bar; max-age=60",
-      "foo1=bar; max-age=60"
+    test: 'MOZILLA0008',
+    received: ['foo=bar; max-age=60', 'foo1=bar; max-age=60'],
+    sent: [
+      { name: 'foo', value: 'bar' },
+      { name: 'foo1', value: 'bar' },
     ],
-    "sent": [
-      { "name": "foo", "value": "bar" },
-      { "name": "foo1", "value": "bar" }
-    ]
   },
   {
-    "test": "MOZILLA0009",
-    "received": [
-      "foo=bar; max-age=60",
-      "foo1=bar; max-age=60",
-      "foo=differentvalue; max-age=0"
+    test: 'MOZILLA0009',
+    received: [
+      'foo=bar; max-age=60',
+      'foo1=bar; max-age=60',
+      'foo=differentvalue; max-age=0',
     ],
-    "sent": [
-      { "name": "foo1", "value": "bar" }
-    ]
+    sent: [{ name: 'foo1', value: 'bar' }],
   },
   {
-    "test": "MOZILLA0010",
-    "received": [
-      "foo=bar; max-age=60",
-      "foo1=bar; max-age=60",
-      "foo=differentvalue; max-age=0",
-      "foo2=evendifferentvalue; max-age=0"
+    test: 'MOZILLA0010',
+    received: [
+      'foo=bar; max-age=60',
+      'foo1=bar; max-age=60',
+      'foo=differentvalue; max-age=0',
+      'foo2=evendifferentvalue; max-age=0',
     ],
-    "sent": [
-      { "name": "foo1", "value": "bar" }
-    ]
+    sent: [{ name: 'foo1', value: 'bar' }],
   },
   {
-    "test": "MOZILLA0011",
-    "received": [
-      "test=parser; domain=.parser.test; ;; ;=; ,,, ===,abc,=; abracadabra! max-age=20;=;;"
+    test: 'MOZILLA0011',
+    received: [
+      'test=parser; domain=.parser.test; ;; ;=; ,,, ===,abc,=; abracadabra! max-age=20;=;;',
     ],
-    "sent": []
+    sent: [],
   },
   {
-    "test": "MOZILLA0012",
-    "received": [
-      "test=\"fubar! = foo;bar\\\";\" parser; max-age=6",
-      "five; max-age=2.63,"
+    test: 'MOZILLA0012',
+    received: [
+      'test="fubar! = foo;bar\\";" parser; max-age=6',
+      'five; max-age=2.63,',
     ],
-    "sent": [
-      { "name": "test", "value": "\"fubar! = foo" }
-    ]
+    sent: [{ name: 'test', value: '"fubar! = foo' }],
   },
   {
-    "test": "MOZILLA0013",
-    "received": [
-      "test=kill; max-age=0",
-      "five; max-age=0"
-    ],
-    "sent": []
+    test: 'MOZILLA0013',
+    received: ['test=kill; max-age=0', 'five; max-age=0'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0014",
-    "received": [
-      "six"
-    ],
-    "sent": []
+    test: 'MOZILLA0014',
+    received: ['six'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0015",
-    "received": [
-      "six",
-      "seven"
-    ],
-    "sent": []
+    test: 'MOZILLA0015',
+    received: ['six', 'seven'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0016",
-    "received": [
-      "six",
-      "seven",
-      " =eight"
-    ],
-    "sent": []
+    test: 'MOZILLA0016',
+    received: ['six', 'seven', ' =eight'],
+    sent: [],
   },
   {
-    "test": "MOZILLA0017",
-    "received": [
-      "six",
-      "seven",
-      " =eight",
-      "test=six"
-    ],
-    "sent": [
-      { "name": "test", "value": "six" }
-    ]
+    test: 'MOZILLA0017',
+    received: ['six', 'seven', ' =eight', 'test=six'],
+    sent: [{ name: 'test', value: 'six' }],
   },
   {
-    "test": "NAME0001",
-    "received": [
-      "a=bar"
-    ],
-    "sent": [
-      { "name": "a", "value": "bar" }
-    ]
+    test: 'NAME0001',
+    received: ['a=bar'],
+    sent: [{ name: 'a', value: 'bar' }],
   },
   {
-    "test": "NAME0002",
-    "received": [
-      "1=bar"
-    ],
-    "sent": [
-      { "name": "1", "value": "bar" }
-    ]
+    test: 'NAME0002',
+    received: ['1=bar'],
+    sent: [{ name: '1', value: 'bar' }],
   },
   {
-    "test": "NAME0003",
-    "received": [
-      "$=bar"
-    ],
-    "sent": [
-      { "name": "$", "value": "bar" }
-    ]
+    test: 'NAME0003',
+    received: ['$=bar'],
+    sent: [{ name: '$', value: 'bar' }],
   },
   {
-    "test": "NAME0004",
-    "received": [
-      "!a=bar"
-    ],
-    "sent": [
-      { "name": "!a", "value": "bar" }
-    ]
+    test: 'NAME0004',
+    received: ['!a=bar'],
+    sent: [{ name: '!a', value: 'bar' }],
   },
   {
-    "test": "NAME0005",
-    "received": [
-      "@a=bar"
-    ],
-    "sent": [
-      { "name": "@a", "value": "bar" }
-    ]
+    test: 'NAME0005',
+    received: ['@a=bar'],
+    sent: [{ name: '@a', value: 'bar' }],
   },
   {
-    "test": "NAME0006",
-    "received": [
-      "#a=bar"
-    ],
-    "sent": [
-      { "name": "#a", "value": "bar" }
-    ]
+    test: 'NAME0006',
+    received: ['#a=bar'],
+    sent: [{ name: '#a', value: 'bar' }],
   },
   {
-    "test": "NAME0007",
-    "received": [
-      "$a=bar"
-    ],
-    "sent": [
-      { "name": "$a", "value": "bar" }
-    ]
+    test: 'NAME0007',
+    received: ['$a=bar'],
+    sent: [{ name: '$a', value: 'bar' }],
   },
   {
-    "test": "NAME0008",
-    "received": [
-      "%a=bar"
-    ],
-    "sent": [
-      { "name": "%a", "value": "bar" }
-    ]
+    test: 'NAME0008',
+    received: ['%a=bar'],
+    sent: [{ name: '%a', value: 'bar' }],
   },
   {
-    "test": "NAME0009",
-    "received": [
-      "^a=bar"
-    ],
-    "sent": [
-      { "name": "^a", "value": "bar" }
-    ]
+    test: 'NAME0009',
+    received: ['^a=bar'],
+    sent: [{ name: '^a', value: 'bar' }],
   },
   {
-    "test": "NAME0010",
-    "received": [
-      "&a=bar"
-    ],
-    "sent": [
-      { "name": "&a", "value": "bar" }
-    ]
+    test: 'NAME0010',
+    received: ['&a=bar'],
+    sent: [{ name: '&a', value: 'bar' }],
   },
   {
-    "test": "NAME0011",
-    "received": [
-      "*a=bar"
-    ],
-    "sent": [
-      { "name": "*a", "value": "bar" }
-    ]
+    test: 'NAME0011',
+    received: ['*a=bar'],
+    sent: [{ name: '*a', value: 'bar' }],
   },
   {
-    "test": "NAME0012",
-    "received": [
-      "(a=bar"
-    ],
-    "sent": [
-      { "name": "(a", "value": "bar" }
-    ]
+    test: 'NAME0012',
+    received: ['(a=bar'],
+    sent: [{ name: '(a', value: 'bar' }],
   },
   {
-    "test": "NAME0013",
-    "received": [
-      ")a=bar"
-    ],
-    "sent": [
-      { "name": ")a", "value": "bar" }
-    ]
+    test: 'NAME0013',
+    received: [')a=bar'],
+    sent: [{ name: ')a', value: 'bar' }],
   },
   {
-    "test": "NAME0014",
-    "received": [
-      "-a=bar"
-    ],
-    "sent": [
-      { "name": "-a", "value": "bar" }
-    ]
+    test: 'NAME0014',
+    received: ['-a=bar'],
+    sent: [{ name: '-a', value: 'bar' }],
   },
   {
-    "test": "NAME0015",
-    "received": [
-      "_a=bar"
-    ],
-    "sent": [
-      { "name": "_a", "value": "bar" }
-    ]
+    test: 'NAME0015',
+    received: ['_a=bar'],
+    sent: [{ name: '_a', value: 'bar' }],
   },
   {
-    "test": "NAME0016",
-    "received": [
-      "+=bar"
-    ],
-    "sent": [
-      { "name": "+", "value": "bar" }
-    ]
+    test: 'NAME0016',
+    received: ['+=bar'],
+    sent: [{ name: '+', value: 'bar' }],
   },
   {
-    "test": "NAME0017",
-    "received": [
-      "=a=bar"
-    ],
-    "sent": []
+    test: 'NAME0017',
+    received: ['=a=bar'],
+    sent: [],
   },
   {
-    "test": "NAME0018",
-    "received": [
-      "a =bar"
-    ],
-    "sent": [
-      { "name": "a", "value": "bar" }
-    ]
+    test: 'NAME0018',
+    received: ['a =bar'],
+    sent: [{ name: 'a', value: 'bar' }],
   },
   {
-    "test": "NAME0019",
-    "received": [
-      "\"a=bar"
-    ],
-    "sent": [
-      { "name": "\"a", "value": "bar" }
-    ]
+    test: 'NAME0019',
+    received: ['"a=bar'],
+    sent: [{ name: '"a', value: 'bar' }],
   },
   {
-    "test": "NAME0020",
-    "received": [
-      "\"a=b\"=bar"
-    ],
-    "sent": [
-      { "name": "\"a", "value": "b\"=bar" }
-    ]
+    test: 'NAME0020',
+    received: ['"a=b"=bar'],
+    sent: [{ name: '"a', value: 'b"=bar' }],
   },
   {
-    "test": "NAME0021",
-    "received": [
-      "\"a=b\"=bar",
-      "\"a=qux"
-    ],
-    "sent": [
-      { "name": "\"a", "value": "qux" }
-    ]
+    test: 'NAME0021',
+    received: ['"a=b"=bar', '"a=qux'],
+    sent: [{ name: '"a', value: 'qux' }],
   },
   {
-    "test": "NAME0022",
-    "received": [
-      "   foo=bar"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'NAME0022',
+    received: ['   foo=bar'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "NAME0023",
-    "received": [
-      "foo;bar=baz"
-    ],
-    "sent": []
+    test: 'NAME0023',
+    received: ['foo;bar=baz'],
+    sent: [],
   },
   {
-    "test": "NAME0024",
-    "received": [
-      "$Version=1; foo=bar"
-    ],
-    "sent": [
-      { "name": "$Version", "value": "1" }
-    ]
+    test: 'NAME0024',
+    received: ['$Version=1; foo=bar'],
+    sent: [{ name: '$Version', value: '1' }],
   },
   {
-    "test": "NAME0025",
-    "received": [
-      "===a=bar"
-    ],
-    "sent": []
+    test: 'NAME0025',
+    received: ['===a=bar'],
+    sent: [],
   },
   {
-    "test": "NAME0026",
-    "received": [
-      "foo=bar    "
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'NAME0026',
+    received: ['foo=bar    '],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "NAME0027",
-    "received": [
-      "foo=bar    ;"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'NAME0027',
+    received: ['foo=bar    ;'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "NAME0028",
-    "received": [
-      "=a"
-    ],
-    "sent": []
+    test: 'NAME0028',
+    received: ['=a'],
+    sent: [],
   },
   {
-    "test": "NAME0029",
-    "received": [
-      "="
-    ],
-    "sent": []
+    test: 'NAME0029',
+    received: ['='],
+    sent: [],
   },
   {
-    "test": "NAME0030",
-    "received": [
-      "foo bar=baz"
-    ],
-    "sent": [
-      { "name": "foo bar", "value": "baz" }
-    ]
+    test: 'NAME0030',
+    received: ['foo bar=baz'],
+    sent: [{ name: 'foo bar', value: 'baz' }],
   },
   {
-    "test": "NAME0031",
-    "received": [
-      "\"foo;bar\"=baz"
-    ],
-    "sent": []
+    test: 'NAME0031',
+    received: ['"foo;bar"=baz'],
+    sent: [],
   },
   {
-    "test": "NAME0032",
-    "received": [
-      "\"foo\\\"bar;baz\"=qux"
-    ],
-    "sent": []
+    test: 'NAME0032',
+    received: ['"foo\\"bar;baz"=qux'],
+    sent: [],
   },
   {
-    "test": "NAME0033",
-    "received": [
-      "=foo=bar",
-      "aaa"
-    ],
-    "sent": []
+    test: 'NAME0033',
+    received: ['=foo=bar', 'aaa'],
+    sent: [],
   },
   {
-    "test": "OPTIONAL_DOMAIN0030",
-    "received": [
-      "foo=bar; domain="
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?optional-domain0030",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'OPTIONAL_DOMAIN0030',
+    received: ['foo=bar; domain='],
+    'sent-to':
+      'http://home.example.org:8888/cookie-parser-result?optional-domain0030',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "OPTIONAL_DOMAIN0041",
-    "received": [
-      "foo=bar; domain=example.org; domain="
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?optional-domain0041",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'OPTIONAL_DOMAIN0041',
+    received: ['foo=bar; domain=example.org; domain='],
+    'sent-to':
+      'http://home.example.org:8888/cookie-parser-result?optional-domain0041',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "OPTIONAL_DOMAIN0042",
-    "received": [
-      "foo=bar; domain=foo.example.org; domain="
-    ],
-    "sent-to": "http://home.example.org:8888/cookie-parser-result?optional-domain0042",
-    "sent": []
+    test: 'OPTIONAL_DOMAIN0042',
+    received: ['foo=bar; domain=foo.example.org; domain='],
+    'sent-to':
+      'http://home.example.org:8888/cookie-parser-result?optional-domain0042',
+    sent: [],
   },
   {
-    "test": "OPTIONAL_DOMAIN0043",
-    "received": [
-      "foo=bar; domain=foo.example.org; domain="
-    ],
-    "sent-to": "http://subdomain.home.example.org:8888/cookie-parser-result?optional-domain0043",
-    "sent": []
+    test: 'OPTIONAL_DOMAIN0043',
+    received: ['foo=bar; domain=foo.example.org; domain='],
+    'sent-to':
+      'http://subdomain.home.example.org:8888/cookie-parser-result?optional-domain0043',
+    sent: [],
   },
   {
-    "test": "ORDERING0001",
-    "received": [
-      "key=val0;",
-      "key=val1; path=/cookie-parser-result",
-      "key=val2; path=/",
-      "key=val3; path=/bar",
-      "key=val4; domain=.example.org",
-      "key=val5; domain=.example.org; path=/cookie-parser-result/foo"
+    test: 'ORDERING0001',
+    received: [
+      'key=val0;',
+      'key=val1; path=/cookie-parser-result',
+      'key=val2; path=/',
+      'key=val3; path=/bar',
+      'key=val4; domain=.example.org',
+      'key=val5; domain=.example.org; path=/cookie-parser-result/foo',
     ],
-    "sent-to": "/cookie-parser-result/foo/baz?ordering0001",
-    "sent": [
-      { "name": "key", "value": "val5" },
-      { "name": "key", "value": "val1" },
-      { "name": "key", "value": "val2" },
-      { "name": "key", "value": "val4" }
-    ]
+    'sent-to': '/cookie-parser-result/foo/baz?ordering0001',
+    sent: [
+      { name: 'key', value: 'val5' },
+      { name: 'key', value: 'val1' },
+      { name: 'key', value: 'val2' },
+      { name: 'key', value: 'val4' },
+    ],
   },
   {
-    "test": "PATH0001",
-    "received": [
-      "a=b; path=/",
-      "x=y; path=/cookie-parser-result"
+    test: 'PATH0001',
+    received: ['a=b; path=/', 'x=y; path=/cookie-parser-result'],
+    sent: [
+      { name: 'x', value: 'y' },
+      { name: 'a', value: 'b' },
     ],
-    "sent": [
-      { "name": "x", "value": "y" },
-      { "name": "a", "value": "b" }
-    ]
   },
   {
-    "test": "PATH0002",
-    "received": [
-      "a=b; path=/cookie-parser-result",
-      "x=y; path=/"
+    test: 'PATH0002',
+    received: ['a=b; path=/cookie-parser-result', 'x=y; path=/'],
+    sent: [
+      { name: 'a', value: 'b' },
+      { name: 'x', value: 'y' },
     ],
-    "sent": [
-      { "name": "a", "value": "b" },
-      { "name": "x", "value": "y" }
-    ]
   },
   {
-    "test": "PATH0003",
-    "received": [
-      "x=y; path=/",
-      "a=b; path=/cookie-parser-result"
+    test: 'PATH0003',
+    received: ['x=y; path=/', 'a=b; path=/cookie-parser-result'],
+    sent: [
+      { name: 'a', value: 'b' },
+      { name: 'x', value: 'y' },
     ],
-    "sent": [
-      { "name": "a", "value": "b" },
-      { "name": "x", "value": "y" }
-    ]
   },
   {
-    "test": "PATH0004",
-    "received": [
-      "x=y; path=/cookie-parser-result",
-      "a=b; path=/"
+    test: 'PATH0004',
+    received: ['x=y; path=/cookie-parser-result', 'a=b; path=/'],
+    sent: [
+      { name: 'x', value: 'y' },
+      { name: 'a', value: 'b' },
     ],
-    "sent": [
-      { "name": "x", "value": "y" },
-      { "name": "a", "value": "b" }
-    ]
   },
   {
-    "test": "PATH0005",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo"
-    ],
-    "sent": []
+    test: 'PATH0005',
+    received: ['foo=bar; path=/cookie-parser-result/foo'],
+    sent: [],
   },
   {
-    "test": "PATH0006",
-    "received": [
-      "foo=bar",
-      "foo=qux; path=/cookie-parser-result/foo"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0006',
+    received: ['foo=bar', 'foo=qux; path=/cookie-parser-result/foo'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0007",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo"
-    ],
-    "sent-to": "/cookie-parser-result/foo?path0007",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0007',
+    received: ['foo=bar; path=/cookie-parser-result/foo'],
+    'sent-to': '/cookie-parser-result/foo?path0007',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0008",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo"
-    ],
-    "sent-to": "/cookie-parser-result/bar?path0008",
-    "sent": []
+    test: 'PATH0008',
+    received: ['foo=bar; path=/cookie-parser-result/foo'],
+    'sent-to': '/cookie-parser-result/bar?path0008',
+    sent: [],
   },
   {
-    "test": "PATH0009",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux"
-    ],
-    "sent-to": "/cookie-parser-result/foo?path0009",
-    "sent": []
+    test: 'PATH0009',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux'],
+    'sent-to': '/cookie-parser-result/foo?path0009',
+    sent: [],
   },
   {
-    "test": "PATH0010",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux"
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux?path0010",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0010',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux'],
+    'sent-to': '/cookie-parser-result/foo/qux?path0010',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0011",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux"
-    ],
-    "sent-to": "/cookie-parser-result/bar/qux?path0011",
-    "sent": []
+    test: 'PATH0011',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux'],
+    'sent-to': '/cookie-parser-result/bar/qux?path0011',
+    sent: [],
   },
   {
-    "test": "PATH0012",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux"
-    ],
-    "sent-to": "/cookie-parser-result/foo/baz?path0012",
-    "sent": []
+    test: 'PATH0012',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux'],
+    'sent-to': '/cookie-parser-result/foo/baz?path0012',
+    sent: [],
   },
   {
-    "test": "PATH0013",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux/"
-    ],
-    "sent-to": "/cookie-parser-result/foo/baz?path0013",
-    "sent": []
+    test: 'PATH0013',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux/'],
+    'sent-to': '/cookie-parser-result/foo/baz?path0013',
+    sent: [],
   },
   {
-    "test": "PATH0014",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux/"
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux?path0014",
-    "sent": []
+    test: 'PATH0014',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux/'],
+    'sent-to': '/cookie-parser-result/foo/qux?path0014',
+    sent: [],
   },
   {
-    "test": "PATH0015",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux/"
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux/?path0015",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0015',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux/'],
+    'sent-to': '/cookie-parser-result/foo/qux/?path0015',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0016",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/"
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux?path0016",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0016',
+    received: ['foo=bar; path=/cookie-parser-result/foo/'],
+    'sent-to': '/cookie-parser-result/foo/qux?path0016',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0017",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/"
-    ],
-    "sent-to": "/cookie-parser-result/foo//qux?path0017",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0017',
+    received: ['foo=bar; path=/cookie-parser-result/foo/'],
+    'sent-to': '/cookie-parser-result/foo//qux?path0017',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0018",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/"
-    ],
-    "sent-to": "/cookie-parser-result/fooqux?path0018",
-    "sent": []
+    test: 'PATH0018',
+    received: ['foo=bar; path=/cookie-parser-result/foo/'],
+    'sent-to': '/cookie-parser-result/fooqux?path0018',
+    sent: [],
   },
   {
-    "test": "PATH0019",
-    "received": [
-      "foo=bar; path"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0019',
+    received: ['foo=bar; path'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0020",
-    "received": [
-      "foo=bar; path="
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0020',
+    received: ['foo=bar; path='],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0021",
-    "received": [
-      "foo=bar; path=/"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0021',
+    received: ['foo=bar; path=/'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0022",
-    "received": [
-      "foo=bar; path= /"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0022',
+    received: ['foo=bar; path= /'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0023",
-    "received": [
-      "foo=bar; Path=/cookie-PARSER-result"
-    ],
-    "sent": []
+    test: 'PATH0023',
+    received: ['foo=bar; Path=/cookie-PARSER-result'],
+    sent: [],
   },
   {
-    "test": "PATH0024",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux?"
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux?path0024",
-    "sent": []
+    test: 'PATH0024',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux?'],
+    'sent-to': '/cookie-parser-result/foo/qux?path0024',
+    sent: [],
   },
   {
-    "test": "PATH0025",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux#"
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux?path0025",
-    "sent": []
+    test: 'PATH0025',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux#'],
+    'sent-to': '/cookie-parser-result/foo/qux?path0025',
+    sent: [],
   },
   {
-    "test": "PATH0026",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/foo/qux;"
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux?path0026",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0026',
+    received: ['foo=bar; path=/cookie-parser-result/foo/qux;'],
+    'sent-to': '/cookie-parser-result/foo/qux?path0026',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0027",
-    "received": [
-      "foo=bar; path=\"/cookie-parser-result/foo/qux;\""
-    ],
-    "sent-to": "/cookie-parser-result/foo/qux?path0027",
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0027',
+    received: ['foo=bar; path="/cookie-parser-result/foo/qux;"'],
+    'sent-to': '/cookie-parser-result/foo/qux?path0027',
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0028",
-    "received": [
-      "foo=bar; path=/cookie-parser-result/f%6Fo/bar"
-    ],
-    "sent-to": "/cookie-parser-result/foo/bar?path0028",
-    "sent": []
+    test: 'PATH0028',
+    received: ['foo=bar; path=/cookie-parser-result/f%6Fo/bar'],
+    'sent-to': '/cookie-parser-result/foo/bar?path0028',
+    sent: [],
   },
   {
-    "test": "PATH0029",
-    "received": [
-      "a=b; \tpath\t=\t/cookie-parser-result\t",
-      "x=y; \tpath\t=\t/book\t"
+    test: 'PATH0029',
+    received: [
+      'a=b; \tpath\t=\t/cookie-parser-result\t',
+      'x=y; \tpath\t=\t/book\t',
     ],
-    "sent": [
-      { "name": "a", "value": "b" }
-    ]
+    sent: [{ name: 'a', value: 'b' }],
   },
   {
-    "test": "PATH0030",
-    "received": [
-      "foo=bar; path=/dog; path="
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'PATH0030',
+    received: ['foo=bar; path=/dog; path='],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "PATH0031",
-    "received": [
-      "foo=bar; path=; path=/dog"
-    ],
-    "sent": []
+    test: 'PATH0031',
+    received: ['foo=bar; path=; path=/dog'],
+    sent: [],
   },
   {
-    "test": "PATH0032",
-    "received": [
-      "foo=bar; path=/cookie-parser-result",
-      "foo=qux; path=/cookie-parser-result/"
+    test: 'PATH0032',
+    received: [
+      'foo=bar; path=/cookie-parser-result',
+      'foo=qux; path=/cookie-parser-result/',
+    ],
+    'sent-to': '/cookie-parser-result/dog?path0032',
+    sent: [
+      { name: 'foo', value: 'qux' },
+      { name: 'foo', value: 'bar' },
     ],
-    "sent-to": "/cookie-parser-result/dog?path0032",
-    "sent": [
-      { "name": "foo", "value": "qux" },
-      { "name": "foo", "value": "bar" }
-    ]
   },
   {
-    "test": "VALUE0001",
-    "received": [
-      "foo=  bar"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
+    test: 'VALUE0001',
+    received: ['foo=  bar'],
+    sent: [{ name: 'foo', value: 'bar' }],
   },
   {
-    "test": "VALUE0002",
-    "received": [
-      "foo=\"bar\""
-    ],
-    "sent": [
-      { "name": "foo", "value": "\"bar\"" }
-    ]
+    test: 'VALUE0002',
+    received: ['foo="bar"'],
+    sent: [{ name: 'foo', value: '"bar"' }],
   },
   {
-    "test": "VALUE0003",
-    "received": [
-      "foo=\"  bar \""
-    ],
-    "sent": [
-      { "name": "foo", "value": "\"  bar \"" }
-    ]
+    test: 'VALUE0003',
+    received: ['foo="  bar "'],
+    sent: [{ name: 'foo', value: '"  bar "' }],
   },
   {
-    "test": "VALUE0004",
-    "received": [
-      "foo=\"bar;baz\""
-    ],
-    "sent": [
-      { "name": "foo", "value": "\"bar" }
-    ]
+    test: 'VALUE0004',
+    received: ['foo="bar;baz"'],
+    sent: [{ name: 'foo', value: '"bar' }],
   },
   {
-    "test": "VALUE0005",
-    "received": [
-      "foo=\"bar=baz\""
-    ],
-    "sent": [
-      { "name": "foo", "value": "\"bar=baz\"" }
-    ]
+    test: 'VALUE0005',
+    received: ['foo="bar=baz"'],
+    sent: [{ name: 'foo', value: '"bar=baz"' }],
   },
   {
-    "test": "VALUE0006",
-    "received": [
-      "\tfoo\t=\tbar\t \t;\tttt"
-    ],
-    "sent": [
-      { "name": "foo", "value": "bar" }
-    ]
-  }
+    test: 'VALUE0006',
+    received: ['\tfoo\t=\tbar\t \t;\tttt'],
+    sent: [{ name: 'foo', value: 'bar' }],
+  },
 ]

--- a/lib/__tests__/ietf.spec.ts
+++ b/lib/__tests__/ietf.spec.ts
@@ -29,11 +29,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { CookieJar, parseDate } from "../cookie";
-import url from "url";
-import parserData from "./data/parser";
-import bsdExampleDates from "./data/dates/bsd-examples";
-import exampleDates from "./data/dates/examples";
+import { CookieJar, parseDate } from '../cookie'
+import url from 'url'
+import parserData from './data/parser'
+import bsdExampleDates from './data/dates/bsd-examples'
+import exampleDates from './data/dates/examples'
 
 describe('IETF http state tests', () => {
   describe('Set/get cookie tests', () => {
@@ -58,7 +58,7 @@ describe('IETF http state tests', () => {
       actual.forEach((actualCookie, idx) => {
         const expectedCookie = expected[idx]
         if (!expectedCookie) {
-          throw new Error("This should not be undefined")
+          throw new Error('This should not be undefined')
         }
         expect(actualCookie.key).toBe(expectedCookie.name)
         expect(actualCookie.value).toBe(expectedCookie.value)
@@ -73,7 +73,7 @@ describe('IETF http state tests', () => {
         if (expected) {
           const date = parseDate(test)
           if (!date) {
-            throw new Error("This should have parsed")
+            throw new Error('This should have parsed')
           }
           expect(date.toUTCString()).toBe(expected)
         } else {
@@ -88,7 +88,7 @@ describe('IETF http state tests', () => {
         if (expected) {
           const date = parseDate(test)
           if (!date) {
-            throw new Error("This should have parsed")
+            throw new Error('This should have parsed')
           }
           expect(date.toUTCString()).toBe(expected)
         } else {

--- a/lib/__tests__/jarSerialization.spec.ts
+++ b/lib/__tests__/jarSerialization.spec.ts
@@ -29,297 +29,307 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Cookie, CookieJar, MemoryCookieStore, SerializedCookie, SerializedCookieJar, Store, version } from "../cookie";
+import {
+  Cookie,
+  CookieJar,
+  MemoryCookieStore,
+  SerializedCookie,
+  SerializedCookieJar,
+  Store,
+  version,
+} from '../cookie'
 
-jest.useFakeTimers();
+jest.useFakeTimers()
 
-describe("cookieJar serialization", () => {
-  it("should use the expected version", () => {
-    expect(version).toBe("5.0.0");
-  });
+describe('cookieJar serialization', () => {
+  it('should use the expected version', () => {
+    expect(version).toBe('5.0.0')
+  })
 
-  it("should provide the list of serialized properties available for a Cookie with `Cookie.serializableProperties`", () => {
+  it('should provide the list of serialized properties available for a Cookie with `Cookie.serializableProperties`', () => {
     expect(Cookie.serializableProperties).toEqual([
-      "key",
-      "value",
-      "expires",
-      "maxAge",
-      "domain",
-      "path",
-      "secure",
-      "httpOnly",
-      "extensions",
-      "hostOnly",
-      "pathIsDefault",
-      "creation",
-      "lastAccessed",
-      "sameSite"
-    ]);
-  });
+      'key',
+      'value',
+      'expires',
+      'maxAge',
+      'domain',
+      'path',
+      'secure',
+      'httpOnly',
+      'extensions',
+      'hostOnly',
+      'pathIsDefault',
+      'creation',
+      'lastAccessed',
+      'sameSite',
+    ])
+  })
 
-  describe("a store without `getAllCookies`", () => {
-    it("cannot call toJSON", () => {
-      const store = new Store();
-      store.synchronous = true;
+  describe('a store without `getAllCookies`', () => {
+    it('cannot call toJSON', () => {
+      const store = new Store()
+      store.synchronous = true
 
-      const jar = new CookieJar(store);
+      const jar = new CookieJar(store)
       expect(() => jar.toJSON()).toThrowError(
-        "getAllCookies is not implemented (therefore jar cannot be serialized)"
-      );
-    });
-  });
+        'getAllCookies is not implemented (therefore jar cannot be serialized)',
+      )
+    })
+  })
 
-  describe("for async stores", () => {
-    it("cannot call toJSON", () => {
-      const store = new MemoryCookieStore();
-      store.synchronous = false;
-      const jar = new CookieJar(store);
+  describe('for async stores', () => {
+    it('cannot call toJSON', () => {
+      const store = new MemoryCookieStore()
+      store.synchronous = false
+      const jar = new CookieJar(store)
       expect(() => jar.toJSON()).toThrowError(
-        "CookieJar store is not synchronous; use async API instead."
-      );
-    });
-  });
+        'CookieJar store is not synchronous; use async API instead.',
+      )
+    })
+  })
 
-  describe("with a small store", () => {
-    let jar: CookieJar;
+  describe('with a small store', () => {
+    let jar: CookieJar
 
     beforeEach(async () => {
-      jar = new CookieJar();
+      jar = new CookieJar()
 
       // domain cookie with custom extension
       await jar.setCookie(
-        "sid=one; domain=example.com; path=/; fubar",
-        "http://example.com/"
-      );
+        'sid=one; domain=example.com; path=/; fubar',
+        'http://example.com/',
+      )
 
       await jar.setCookie(
-        "sid=two; domain=example.net; path=/; fubar",
-        "http://example.net/"
-      );
-    });
+        'sid=two; domain=example.net; path=/; fubar',
+        'http://example.net/',
+      )
+    })
 
-    it("should serialize synchronously", () => {
-      const serializedJar = jar.serializeSync();
+    it('should serialize synchronously', () => {
+      const serializedJar = jar.serializeSync()
       if (!serializedJar) {
-        throw new Error("This should not be undefined");
+        throw new Error('This should not be undefined')
       }
-      expectDataToMatchSerializationSchema(serializedJar);
-      expect(serializedJar.cookies.length).toBe(2);
-    });
+      expectDataToMatchSerializationSchema(serializedJar)
+      expect(serializedJar.cookies.length).toBe(2)
+    })
 
-    it("should deserialize synchronously", () => {
-      const serializedJar = jar.serializeSync();
+    it('should deserialize synchronously', () => {
+      const serializedJar = jar.serializeSync()
       if (!serializedJar) {
-        throw new Error("This should not be undefined");
+        throw new Error('This should not be undefined')
       }
-      const deserializedJar = CookieJar.deserializeSync(serializedJar);
-      expect(jar.store).toEqual(deserializedJar.store);
-    });
+      const deserializedJar = CookieJar.deserializeSync(serializedJar)
+      expect(jar.store).toEqual(deserializedJar.store)
+    })
 
-    it("should serialize asynchronously", async () => {
-      const serializedJar = await jar.serialize();
-      expectDataToMatchSerializationSchema(serializedJar);
-      expect(serializedJar.cookies.length).toBe(2);
-    });
+    it('should serialize asynchronously', async () => {
+      const serializedJar = await jar.serialize()
+      expectDataToMatchSerializationSchema(serializedJar)
+      expect(serializedJar.cookies.length).toBe(2)
+    })
 
-    it("should deserialize asynchronously", async () => {
-      const serializedJar = await jar.serialize();
-      const deserializedJar = await CookieJar.deserialize(serializedJar);
-      expect(jar.store).toEqual(deserializedJar.store);
-    });
-  });
+    it('should deserialize asynchronously', async () => {
+      const serializedJar = await jar.serialize()
+      const deserializedJar = await CookieJar.deserialize(serializedJar)
+      expect(jar.store).toEqual(deserializedJar.store)
+    })
+  })
 
-  describe("with a small store for cloning", () => {
-    let jar: CookieJar;
+  describe('with a small store for cloning', () => {
+    let jar: CookieJar
 
     beforeEach(async () => {
-      jar = new CookieJar();
+      jar = new CookieJar()
 
       // domain cookie with custom extension
       await jar.setCookie(
-        "sid=three; domain=example.com; path=/; cloner",
-        "http://example.com/"
-      );
+        'sid=three; domain=example.com; path=/; cloner',
+        'http://example.com/',
+      )
 
       await jar.setCookie(
-        "sid=four; domain=example.net; path=/; cloner",
-        "http://example.net/"
-      );
-    });
+        'sid=four; domain=example.net; path=/; cloner',
+        'http://example.net/',
+      )
+    })
 
-    it("should contain the same contents when cloned asynchronously", async () => {
-      const clonedJar = await jar.clone(new MemoryCookieStore());
-      expect(clonedJar.store).toEqual(jar.store);
-    });
+    it('should contain the same contents when cloned asynchronously', async () => {
+      const clonedJar = await jar.clone(new MemoryCookieStore())
+      expect(clonedJar.store).toEqual(jar.store)
+    })
 
-    it("should contain the same contents when cloned synchronously", () => {
-      const clonedJar = jar.cloneSync(new MemoryCookieStore());
+    it('should contain the same contents when cloned synchronously', () => {
+      const clonedJar = jar.cloneSync(new MemoryCookieStore())
       if (!clonedJar) {
-        throw new Error("This should not be undefined");
+        throw new Error('This should not be undefined')
       }
-      expect(clonedJar.store).toEqual(jar.store);
-    });
+      expect(clonedJar.store).toEqual(jar.store)
+    })
 
-    it("should raise an error when attempting to synchronously clone to an async store", () => {
-      const newStore = new MemoryCookieStore();
-      newStore.synchronous = false;
+    it('should raise an error when attempting to synchronously clone to an async store', () => {
+      const newStore = new MemoryCookieStore()
+      newStore.synchronous = false
       expect(() => jar.cloneSync(newStore)).toThrowError(
-        "CookieJar clone destination store is not synchronous; use async API instead."
-      );
-    });
-  });
+        'CookieJar clone destination store is not synchronous; use async API instead.',
+      )
+    })
+  })
 
-  describe("with a moderately-sized store", () => {
-    let jar: CookieJar;
-    let expires: Date;
+  describe('with a moderately-sized store', () => {
+    let jar: CookieJar
+    let expires: Date
 
     beforeEach(async () => {
-      expires = new Date(Date.now() + 86400000);
+      expires = new Date(Date.now() + 86400000)
 
-      jar = new CookieJar();
+      jar = new CookieJar()
 
       // Do paths first since the MemoryCookieStore index is domain at the top
       // level. This should cause the preservation of creation order in
       // getAllCookies to be exercised.
-      const paths = ["/", "/foo", "/foo/bar"];
-      const domains = ["example.com", "www.example.com", "example.net"];
+      const paths = ['/', '/foo', '/foo/bar']
+      const domains = ['example.com', 'www.example.com', 'example.net']
       for await (const path of paths) {
         for await (const domain of domains) {
-          const key = "key";
-          const value = JSON.stringify({ path, domain });
-          const cookie = new Cookie({ expires, domain, path, key, value });
-          await jar.setCookie(cookie, `http://${domain}/`);
+          const key = 'key'
+          const value = JSON.stringify({ path, domain })
+          const cookie = new Cookie({ expires, domain, path, key, value })
+          await jar.setCookie(cookie, `http://${domain}/`)
         }
       }
 
       // corner cases
       const cornerCases = [
-        { expires: "Infinity", key: "infExp", value: "infExp" },
-        { maxAge: 3600, key: "max", value: "max" },
+        { expires: 'Infinity', key: 'infExp', value: 'infExp' },
+        { maxAge: 3600, key: 'max', value: 'max' },
         {
           expires,
-          key: "flags",
-          value: "flags",
+          key: 'flags',
+          value: 'flags',
           secure: true,
-          httpOnly: true
+          httpOnly: true,
         },
         {
           expires,
-          key: "honly",
-          value: "honly",
+          key: 'honly',
+          value: 'honly',
           hostOnly: true,
-          domain: "www.example.org"
-        }
-      ];
+          domain: 'www.example.org',
+        },
+      ]
 
       for await (const cornerCase of cornerCases) {
-        const domain = cornerCase.domain ?? "example.org";
-        const path = "/";
-        const cookie = new Cookie({ ...cornerCase, domain, path });
-        await jar.setCookie(cookie, "https://www.example.org/", {
-          ignoreError: true
-        });
+        const domain = cornerCase.domain ?? 'example.org'
+        const path = '/'
+        const cookie = new Cookie({ ...cornerCase, domain, path })
+        await jar.setCookie(cookie, 'https://www.example.org/', {
+          ignoreError: true,
+        })
       }
-    });
+    })
 
-    it("should have the expected metadata", async () => {
-      const serializedJar = await jar.serialize();
-      expect(serializedJar.version).toBe(`tough-cookie@${version}`);
-      expect(serializedJar.rejectPublicSuffixes).toBe(true);
-      expect(serializedJar.storeType).toBe("MemoryCookieStore");
-    });
+    it('should have the expected metadata', async () => {
+      const serializedJar = await jar.serialize()
+      expect(serializedJar.version).toBe(`tough-cookie@${version}`)
+      expect(serializedJar.rejectPublicSuffixes).toBe(true)
+      expect(serializedJar.storeType).toBe('MemoryCookieStore')
+    })
 
-    it("should contain the expected serialized cookies", async () => {
-      const serializedJar = await jar.serialize();
-      expect(serializedJar.cookies.length).toBe(13);
-      expectDataToMatchSerializationSchema(serializedJar);
+    it('should contain the expected serialized cookies', async () => {
+      const serializedJar = await jar.serialize()
+      expect(serializedJar.cookies.length).toBe(13)
+      expectDataToMatchSerializationSchema(serializedJar)
       serializedJar.cookies.forEach((serializedCookie) => {
-        if (serializedCookie.key === "key") {
-          const parsedValue = JSON.parse(serializedCookie.value ?? "{}") as {
-            domain?: string,
+        if (serializedCookie.key === 'key') {
+          const parsedValue = JSON.parse(serializedCookie.value ?? '{}') as {
+            domain?: string
             path?: string
-          };
-          expect(typeof parsedValue.domain).toBe("string");
-          expect(typeof parsedValue.path).toBe("string");
+          }
+          expect(typeof parsedValue.domain).toBe('string')
+          expect(typeof parsedValue.path).toBe('string')
         }
 
         if (
-          serializedCookie.key === "infExp" ||
-          serializedCookie.key === "max"
+          serializedCookie.key === 'infExp' ||
+          serializedCookie.key === 'max'
         ) {
-          expect(serializedCookie.expires).toBeFalsy();
+          expect(serializedCookie.expires).toBeFalsy()
         } else {
-          expect(serializedCookie.expires).toBe(expires.toISOString());
+          expect(serializedCookie.expires).toBe(expires.toISOString())
         }
 
-        if (serializedCookie.key === "max") {
-          expect(serializedCookie.maxAge).toBe(3600);
+        if (serializedCookie.key === 'max') {
+          expect(serializedCookie.maxAge).toBe(3600)
         } else {
-          expect(serializedCookie.maxAge).toBeUndefined();
+          expect(serializedCookie.maxAge).toBeUndefined()
         }
 
-        if (serializedCookie.key === "flags") {
-          expect(serializedCookie.secure).toBe(true);
-          expect(serializedCookie.httpOnly).toBe(true);
+        if (serializedCookie.key === 'flags') {
+          expect(serializedCookie.secure).toBe(true)
+          expect(serializedCookie.httpOnly).toBe(true)
         } else {
-          expect(serializedCookie.secure).toBeUndefined();
-          expect(serializedCookie.httpOnly).toBeUndefined();
+          expect(serializedCookie.secure).toBeUndefined()
+          expect(serializedCookie.httpOnly).toBeUndefined()
         }
 
-        expect(serializedCookie.hostOnly).toBe(serializedCookie.key === "honly");
+        expect(serializedCookie.hostOnly).toBe(serializedCookie.key === 'honly')
 
-        expect(serializedCookie.creation).toBe(new Date().toISOString());
-        expect(serializedCookie.lastAccessed).toBe(new Date().toISOString());
-      });
-    });
+        expect(serializedCookie.creation).toBe(new Date().toISOString())
+        expect(serializedCookie.lastAccessed).toBe(new Date().toISOString())
+      })
+    })
 
-    it("should be the same when deserialized", async () => {
-      const serializedJar = await jar.serialize();
-      const deserializedJar = await CookieJar.deserialize(serializedJar);
-      expect(deserializedJar.store).toEqual(jar.store);
+    it('should be the same when deserialized', async () => {
+      const serializedJar = await jar.serialize()
+      const deserializedJar = await CookieJar.deserialize(serializedJar)
+      expect(deserializedJar.store).toEqual(jar.store)
 
-      const cookies = await deserializedJar.getCookies("http://example.org/");
+      const cookies = await deserializedJar.getCookies('http://example.org/')
       expect(cookies).toEqual([
         expect.objectContaining({
-          key: "infExp",
-          expires: "Infinity"
+          key: 'infExp',
+          expires: 'Infinity',
         }),
         expect.objectContaining({
-          key: "max"
-        })
-      ]);
-      expect((cookies[0] as Cookie).TTL(Date.now())).toBe(Infinity);
-      expect((cookies[1] as Cookie).TTL(Date.now())).toBe(3600 * 1000);
-    });
-  });
-});
+          key: 'max',
+        }),
+      ])
+      expect((cookies[0] as Cookie).TTL(Date.now())).toBe(Infinity)
+      expect((cookies[1] as Cookie).TTL(Date.now())).toBe(3600 * 1000)
+    })
+  })
+})
 
-function expectDataToMatchSerializationSchema(serializedJar: SerializedCookieJar) {
-  expect(serializedJar).not.toBeNull();
-  expect(serializedJar).toBeInstanceOf(Object);
-  expect(serializedJar.version).toBe(`tough-cookie@${version}`);
-  expect(serializedJar.storeType).toBe("MemoryCookieStore");
-  expect(serializedJar.rejectPublicSuffixes).toBe(true);
-  expect(serializedJar.cookies).toBeInstanceOf(Array);
-  serializedJar.cookies.forEach((cookie) => validateSerializedCookie(cookie));
+function expectDataToMatchSerializationSchema(
+  serializedJar: SerializedCookieJar,
+) {
+  expect(serializedJar).not.toBeNull()
+  expect(serializedJar).toBeInstanceOf(Object)
+  expect(serializedJar.version).toBe(`tough-cookie@${version}`)
+  expect(serializedJar.storeType).toBe('MemoryCookieStore')
+  expect(serializedJar.rejectPublicSuffixes).toBe(true)
+  expect(serializedJar.cookies).toBeInstanceOf(Array)
+  serializedJar.cookies.forEach((cookie) => validateSerializedCookie(cookie))
 }
 
 const serializedCookiePropTypes: { [key: string]: string } = {
-  key: "string",
-  value: "string",
-  expires: "isoDate", // if "Infinity" it's supposed to be missing
-  maxAge: "intOrInf",
-  domain: "string",
-  path: "string",
-  secure: "boolean",
-  httpOnly: "boolean",
-  extensions: "array", // of strings, technically
-  hostOnly: "boolean",
-  pathIsDefault: "boolean",
-  creation: "isoDate",
-  lastAccessed: "isoDate",
-  sameSite: "string"
-};
+  key: 'string',
+  value: 'string',
+  expires: 'isoDate', // if "Infinity" it's supposed to be missing
+  maxAge: 'intOrInf',
+  domain: 'string',
+  path: 'string',
+  secure: 'boolean',
+  httpOnly: 'boolean',
+  extensions: 'array', // of strings, technically
+  hostOnly: 'boolean',
+  pathIsDefault: 'boolean',
+  creation: 'isoDate',
+  lastAccessed: 'isoDate',
+  sameSite: 'string',
+}
 
 function validateSerializedCookie(cookie: SerializedCookie) {
   expect(typeof cookie).toBe('object')

--- a/lib/__tests__/nodeUtilFallback.spec.ts
+++ b/lib/__tests__/nodeUtilFallback.spec.ts
@@ -1,7 +1,7 @@
-import { getCustomInspectSymbol, getUtilInspect } from "../utilHelper";
-import util from "util";
-import { Cookie, CookieJar, MemoryCookieStore } from "../cookie";
-import { inspectFallback } from "../memstore";
+import { getCustomInspectSymbol, getUtilInspect } from '../utilHelper'
+import util from 'util'
+import { Cookie, CookieJar, MemoryCookieStore } from '../cookie'
+import { inspectFallback } from '../memstore'
 
 jest.useFakeTimers()
 
@@ -49,7 +49,7 @@ describe('Node util module fallback for non-node environments', () => {
     it('custom inspect for Cookie still works', () => {
       const cookie = Cookie.parse('a=1; Domain=example.com; Path=/')
       if (!cookie) {
-        throw new Error("This should not be undefined")
+        throw new Error('This should not be undefined')
       }
       expect(cookie.inspect()).toEqual(util.inspect(cookie))
     })

--- a/lib/__tests__/parse.spec.ts
+++ b/lib/__tests__/parse.spec.ts
@@ -1,5 +1,5 @@
-import { Cookie } from "../cookie";
-import { performance } from "node:perf_hooks";
+import { Cookie } from '../cookie'
+import { performance } from 'node:perf_hooks'
 
 describe('Cookie.parse', () => {
   it.each([

--- a/lib/__tests__/regression.spec.ts
+++ b/lib/__tests__/regression.spec.ts
@@ -1,4 +1,4 @@
-import { Cookie, CookieJar } from "../cookie";
+import { Cookie, CookieJar } from '../cookie'
 
 const url = 'http://www.example.com'
 

--- a/lib/__tests__/removeAll.spec.ts
+++ b/lib/__tests__/removeAll.spec.ts
@@ -1,6 +1,12 @@
-import { Callback, Cookie, CookieJar, MemoryCookieStore, Store } from "../cookie";
-import spyOn = jest.spyOn;
-import SpyInstance = jest.SpyInstance;
+import {
+  Callback,
+  Cookie,
+  CookieJar,
+  MemoryCookieStore,
+  Store,
+} from '../cookie'
+import spyOn = jest.spyOn
+import SpyInstance = jest.SpyInstance
 
 const url = 'http://example.com/index.html'
 
@@ -34,17 +40,21 @@ describe('store removeAllCookies API', () => {
         store,
         'removeCookie',
       )
-      spy.mockImplementationOnce((domain: string, path: string, key: string, callback: Callback<void>) =>
-        _removeCookie.call(store, domain, path, key, callback),
+      spy.mockImplementationOnce(
+        (domain: string, path: string, key: string, callback: Callback<void>) =>
+          _removeCookie.call(store, domain, path, key, callback),
       )
-      spy.mockImplementationOnce((domain: string, path: string, key: string, callback: Callback<void>) =>
-        _removeCookie.call(store, domain, path, key, callback),
+      spy.mockImplementationOnce(
+        (domain: string, path: string, key: string, callback: Callback<void>) =>
+          _removeCookie.call(store, domain, path, key, callback),
       )
-      spy.mockImplementationOnce((domain: string, path: string, key: string, callback: Callback<void>) =>
-        _removeCookie.call(store, domain, path, key, callback),
+      spy.mockImplementationOnce(
+        (domain: string, path: string, key: string, callback: Callback<void>) =>
+          _removeCookie.call(store, domain, path, key, callback),
       )
-      spy.mockImplementationOnce((_domain, _path, _key, callback: Callback<void>) =>
-        callback(new Error('something happened 4')),
+      spy.mockImplementationOnce(
+        (_domain, _path, _key, callback: Callback<void>) =>
+          callback(new Error('something happened 4')),
       )
 
       await expect(jar.removeAllCookies()).rejects.toThrowError(
@@ -73,14 +83,21 @@ describe('store removeAllCookies API', () => {
         store,
         'removeCookie',
       )
-      spy.mockImplementation((domain: string, path: string, key: string, callback: Callback<void>) => {
-        if (spy.mock.calls.length % 2 === 1) {
-          return callback(
-            new Error(`something happened ${spy.mock.calls.length}`),
-          )
-        }
-        return _removeCookie.call(store, domain, path, key, callback)
-      })
+      spy.mockImplementation(
+        (
+          domain: string,
+          path: string,
+          key: string,
+          callback: Callback<void>,
+        ) => {
+          if (spy.mock.calls.length % 2 === 1) {
+            return callback(
+              new Error(`something happened ${spy.mock.calls.length}`),
+            )
+          }
+          return _removeCookie.call(store, domain, path, key, callback)
+        },
+      )
 
       await expect(jar.removeAllCookies()).rejects.toThrowError(
         'something happened 1',
@@ -145,7 +162,7 @@ class StoreWithoutRemoveAll extends Store {
     callback?: Callback<Cookie>,
   ): unknown {
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return callback(undefined, undefined)
   }
@@ -168,7 +185,7 @@ class StoreWithoutRemoveAll extends Store {
     callback?: Callback<Cookie[]>,
   ): unknown {
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return callback(undefined, [])
   }
@@ -179,7 +196,7 @@ class StoreWithoutRemoveAll extends Store {
     this.stats.put++
     this.cookies.push(cookie)
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return callback(undefined)
   }
@@ -189,7 +206,7 @@ class StoreWithoutRemoveAll extends Store {
   override getAllCookies(callback?: Callback<Cookie[]>): unknown {
     this.stats.getAll++
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return callback(undefined, this.cookies.slice())
   }
@@ -213,7 +230,7 @@ class StoreWithoutRemoveAll extends Store {
   ): unknown {
     this.stats.remove++
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return callback(undefined)
   }
@@ -236,7 +253,7 @@ class MemoryStoreExtension extends MemoryCookieStore {
   override getAllCookies(callback?: Callback<Cookie[]>): unknown {
     this.stats.getAll++
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return super.getAllCookies(callback)
   }
@@ -260,7 +277,7 @@ class MemoryStoreExtension extends MemoryCookieStore {
   ): unknown {
     this.stats.remove++
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return super.removeCookie(domain, path, key, callback)
   }
@@ -270,7 +287,7 @@ class MemoryStoreExtension extends MemoryCookieStore {
   override removeAllCookies(callback?: Callback<void>): unknown {
     this.stats.removeAll++
     if (!callback) {
-      throw new Error("This should not be undefined")
+      throw new Error('This should not be undefined')
     }
     return super.removeAllCookies(callback)
   }

--- a/lib/__tests__/sameSite.spec.ts
+++ b/lib/__tests__/sameSite.spec.ts
@@ -1,4 +1,4 @@
-import { Cookie, CookieJar } from "../cookie";
+import { Cookie, CookieJar } from '../cookie'
 
 const url = 'http://example.com/index.html'
 

--- a/lib/cookie.ts
+++ b/lib/cookie.ts
@@ -29,16 +29,16 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as punycode from "punycode/";
-import urlParse from "url-parse";
-import * as pubsuffix from "./pubsuffix-psl";
-import { Store } from "./store";
-import { MemoryCookieStore } from "./memstore";
-import { pathMatch } from "./pathMatch";
-import * as validators from "./validators";
-import { version } from "./version";
-import { permuteDomain } from "./permuteDomain";
-import { getCustomInspectSymbol } from "./utilHelper";
+import * as punycode from 'punycode/'
+import urlParse from 'url-parse'
+import * as pubsuffix from './pubsuffix-psl'
+import { Store } from './store'
+import { MemoryCookieStore } from './memstore'
+import { pathMatch } from './pathMatch'
+import * as validators from './validators'
+import { version } from './version'
+import { permuteDomain } from './permuteDomain'
+import { getCustomInspectSymbol } from './utilHelper'
 
 // From RFC6265 S4.1.1
 // note that it excludes \x3B ";"

--- a/lib/utilHelper.ts
+++ b/lib/utilHelper.ts
@@ -1,6 +1,5 @@
 function requireUtil() {
   try {
-    // eslint-disable-next-line no-restricted-modules
     return require('util')
   } catch (e) {
     return null


### PR DESCRIPTION
Extending `prettier` extends `eslint-config-prettier`. To leverage the full power of Prettier via `eslint-plugin-prettier`, we should extend `plugin:prettier/recommended`.