### PR TITLE
Remove url parse library

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -30,7 +30,6 @@
  */
 "use strict";
 const punycode = require("punycode/");
-const urlParse = require("url-parse");
 const pubsuffix = require("./pubsuffix-psl");
 const Store = require("./store").Store;
 const MemoryCookieStore = require("./memstore").MemoryCookieStore;
@@ -788,7 +787,7 @@ function getCookieContext(url) {
     // Silently swallow error
   }
 
-  return urlParse(url);
+  return new URL(url);
 }
 
 const cookieDefaults = {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   "dependencies": {
     "psl": "^1.1.33",
     "punycode": "^2.1.1",
-    "universalify": "^0.2.0",
-    "url-parse": "^1.5.3"
+    "universalify": "^0.2.0"
   }
 }

--- a/test/cookie_jar_test.js
+++ b/test/cookie_jar_test.js
@@ -219,12 +219,12 @@ vows
     "Setting a prefix IPv6 cookie": {
       topic: function() {
         const cj = new CookieJar();
-        const c = Cookie.parse("a=b; Domain=[::ffff:127.0.0.1]; Path=/");
+        const c = Cookie.parse("a=b; Domain=[::ffff:127:0:0:1]; Path=/");
         assert.strictEqual(c.hostOnly, null);
         assert.instanceOf(c.creation, Date);
         assert.strictEqual(c.lastAccessed, null);
         c.creation = new Date(Date.now() - 10000);
-        cj.setCookie(c, "http://[::ffff:127.0.0.1]/", this.callback);
+        cj.setCookie(c, "http://[::ffff:127:0:0:1]/", this.callback);
       },
       works: function(c) {
         assert.instanceOf(c, Cookie);

--- a/test/cookie_jar_test.js
+++ b/test/cookie_jar_test.js
@@ -530,7 +530,7 @@ vows
           const cj = new CookieJar();
           cj.setCookie(
             "i=9; Domain=kyoto.jp; Path=/",
-            "kyoto.jp",
+            "https://kyoto.jp",
             this.callback
           );
         },


### PR DESCRIPTION
This PR aims to fix this issue:
https://github.com/salesforce/tough-cookie/issues/278

It also fixes this issue:
https://github.com/salesforce/tough-cookie/issues/260

This PR removes url-parse library and replaces url-parse library with native URL module.

Two commits were necessary to fix a couple issues found during tests:
- First test issue is related to IPv6 parsing. The original URL `http://[::ffff:127.0.0.1]/` parses to `http://[::ffff:7f00:1]/` according to IPv6 parsing specification (https://url.spec.whatwg.org/#concept-ipv6-parser); url-parse library parses this URL to `http://[::ffff:127.0.0.1]/`. In order to fix it, I changed the used domain in the test suite;

- Another test issue found is related to an invalid URL (`kyoto.jp`, without protocol). This issue is located in `CookieJar setCookie errors` batch. `url-parse` library allows it, but URL module does not, so I added a protocol in the domain.