### PR TITLE
Avoid using `arguments`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,10 +13,6 @@
   },
   "reportUnusedDisableDirectives": true,
   "rules": {
-    // this is only needed because `createPromiseCallback` uses arguments to support the callback-style api
-    // we should strongly consider dropping the callback and sync api variants (in say v6) to reduce the
-    // surface area and complexity of tough-cookie
-    "prefer-rest-params": "warn",
     "max-lines": ["warn", 500]
   }
 }

--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -49,7 +49,7 @@ describe('CookieJar', () => {
   })
 
   describe('setCookie', () => {
-    let cookie: Cookie
+    let cookie: Cookie | undefined
 
     apiVariants(
       'should resolve to a Cookie',
@@ -83,8 +83,8 @@ describe('CookieJar', () => {
       },
       () => {
         expect(cookie).toBeInstanceOf(Cookie)
-        expect(cookie.key).toBe('foo')
-        expect(cookie.value).toBe('bar')
+        expect(cookie?.key).toBe('foo')
+        expect(cookie?.value).toBe('bar')
       },
     )
 
@@ -185,8 +185,8 @@ describe('CookieJar', () => {
           lastAccessed: t1,
         }),
       )
-      expect(cookie.TTL()).toBe(Infinity)
-      expect(cookie.isPersistent()).toBe(false)
+      expect(cookie?.TTL()).toBe(Infinity)
+      expect(cookie?.isPersistent()).toBe(false)
 
       // updates the last access when retrieving a cookie
       jest.advanceTimersByTime(10000)
@@ -279,7 +279,7 @@ describe('CookieJar', () => {
         'a=b; Domain=example.com; Path=/',
         'http://www.app.example.com/index.html',
       )
-      expect(cookie.domain).toBe('example.com')
+      expect(cookie?.domain).toBe('example.com')
     })
 
     it('should allow a sub-path cookie on a super-domain', async () => {
@@ -348,8 +348,8 @@ describe('CookieJar', () => {
           lastAccessed: t0,
         }),
       )
-      expect(cookie.TTL()).toBe(Infinity)
-      expect(cookie.isPersistent()).toBe(false)
+      expect(cookie?.TTL()).toBe(Infinity)
+      expect(cookie?.isPersistent()).toBe(false)
     })
   })
 
@@ -800,7 +800,7 @@ describe('CookieJar', () => {
   })
 
   describe('getSetCookieStrings', () => {
-    let cookieHeaders: string[]
+    let cookieHeaders: string[] | undefined
 
     describe('api', () => {
       beforeEach(async () => {

--- a/lib/__tests__/data/parser.ts
+++ b/lib/__tests__/data/parser.ts
@@ -1,3 +1,5 @@
+// This file just contains test data, so we don't care about the number of lines.
+/* eslint-disable max-lines */
 export default [
   {
     test: '0001',

--- a/lib/__tests__/removeAll.spec.ts
+++ b/lib/__tests__/removeAll.spec.ts
@@ -154,7 +154,7 @@ class StoreWithoutRemoveAll extends Store {
     if (!callback) {
       throw new Error('This should not be undefined')
     }
-    return callback(undefined, undefined)
+    return callback(null, undefined)
   }
 
   override findCookies(
@@ -177,7 +177,7 @@ class StoreWithoutRemoveAll extends Store {
     if (!callback) {
       throw new Error('This should not be undefined')
     }
-    return callback(undefined, [])
+    return callback(null, [])
   }
 
   override putCookie(cookie: Cookie): Promise<void>
@@ -188,7 +188,7 @@ class StoreWithoutRemoveAll extends Store {
     if (!callback) {
       throw new Error('This should not be undefined')
     }
-    return callback(undefined)
+    return callback(null)
   }
 
   override getAllCookies(): Promise<Cookie[]>
@@ -198,7 +198,7 @@ class StoreWithoutRemoveAll extends Store {
     if (!callback) {
       throw new Error('This should not be undefined')
     }
-    return callback(undefined, this.cookies.slice())
+    return callback(null, this.cookies.slice())
   }
 
   override removeCookie(
@@ -222,7 +222,7 @@ class StoreWithoutRemoveAll extends Store {
     if (!callback) {
       throw new Error('This should not be undefined')
     }
-    return callback(undefined)
+    return callback(null)
   }
 }
 

--- a/lib/__tests__/removeAll.spec.ts
+++ b/lib/__tests__/removeAll.spec.ts
@@ -138,18 +138,18 @@ class StoreWithoutRemoveAll extends Store {
     domain: string,
     path: string,
     key: string,
-  ): Promise<Cookie>
+  ): Promise<Cookie | undefined>
   override findCookie(
     domain: string,
     path: string,
     key: string,
-    callback: Callback<Cookie>,
+    callback: Callback<Cookie | undefined>,
   ): void
   override findCookie(
     _domain: string,
     _path: string,
     _key: string,
-    callback?: Callback<Cookie>,
+    callback?: Callback<Cookie | undefined>,
   ): unknown {
     if (!callback) {
       throw new Error('This should not be undefined')

--- a/lib/cookie/cookie.ts
+++ b/lib/cookie/cookie.ts
@@ -29,6 +29,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+// This file was too big before we added max-lines, and it's ongoing work to reduce its size.
+/* eslint max-lines: [1, 750] */
+
 import * as pubsuffix from '../pubsuffix-psl'
 import * as validators from '../validators'
 import { getCustomInspectSymbol } from '../utilHelper'
@@ -540,7 +543,11 @@ export class Cookie {
     ) {
       return false
     }
-    if (this.maxAge != null && this.maxAge <= 0) {
+    if (
+      this.maxAge != null &&
+      this.maxAge !== 'Infinity' &&
+      (this.maxAge === '-Infinity' || this.maxAge <= 0)
+    ) {
       return false // "Max-Age=" non-zero-digit *DIGIT
     }
     if (this.path != null && !PATH_VALUE.test(this.path)) {

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -24,6 +24,9 @@ import { domainMatch } from './domainMatch'
 import { cookieCompare } from './cookieCompare'
 import { version } from '../version'
 
+// This file was too big before we added max-lines, and it's ongoing work to reduce its size.
+/* eslint max-lines: [1, 1200] */
+
 const defaultSetCookieOptions: SetCookieOptions = {
   loose: false,
   sameSiteContext: undefined,

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -176,7 +176,7 @@ export class CookieJar {
         'CookieJar store is not synchronous; use async API instead.',
       )
     }
-    let syncErr: Error | undefined
+    let syncErr: Error | null = null
     let syncResult: T | undefined = undefined
     fn.call(this, (error, result) => {
       syncErr = error
@@ -406,7 +406,7 @@ export class CookieJar {
         return this.putCookie(newCookie).then(
           () => {
             if (cb) {
-              cb(undefined, undefined)
+              cb(null, undefined)
             }
           },
           (error: Error) => {
@@ -419,7 +419,7 @@ export class CookieJar {
     }
 
     function withCookie(
-      err: Error | undefined,
+      err: Error | null,
       oldCookie: Cookie | undefined | null,
     ): void {
       if (err) {
@@ -427,7 +427,7 @@ export class CookieJar {
         return
       }
 
-      const next = function (err: Error | undefined): void {
+      const next = function (err: Error | null): void {
         if (err || typeof cookie === 'string') {
           cb(err)
         } else {
@@ -616,7 +616,7 @@ export class CookieJar {
         }
 
         if (cookies == null) {
-          cb(undefined, [])
+          cb(null, [])
           return
         }
 
@@ -672,14 +672,14 @@ export class CookieJar {
     }
 
     const next: Callback<Cookie[]> = function (
-      err: Error | undefined,
+      err: Error | null,
       cookies: Cookie[] | undefined,
     ) {
       if (err || cookies === undefined) {
         promiseCallback.callback(err)
       } else {
         promiseCallback.callback(
-          undefined,
+          null,
           cookies
             .sort(cookieCompare)
             .map((c) => c.cookieString())
@@ -728,7 +728,7 @@ export class CookieJar {
     }
 
     const next: Callback<Cookie[]> = function (
-      err: Error | undefined,
+      err: Error | null,
       cookies: Cookie[] | undefined,
     ) {
       if (err || cookies === undefined) {
@@ -812,7 +812,7 @@ export class CookieJar {
       }
 
       if (cookies == null) {
-        promiseCallback.callback(undefined, serialized)
+        promiseCallback.callback(null, serialized)
         return
       }
 
@@ -826,7 +826,7 @@ export class CookieJar {
         return serializedCookie
       })
 
-      promiseCallback.callback(undefined, serialized)
+      promiseCallback.callback(null, serialized)
     })
 
     return promiseCallback.promise
@@ -863,7 +863,7 @@ export class CookieJar {
 
     cookies = cookies.slice() // do not modify the original
 
-    const putNext = (err?: Error): void => {
+    const putNext = (err: Error | null): void => {
       if (err) {
         return callback(err, undefined)
       }
@@ -881,14 +881,14 @@ export class CookieJar {
         }
 
         if (cookie === null) {
-          return putNext(undefined) // skip this cookie
+          return putNext(null) // skip this cookie
         }
 
         this.store.putCookie(cookie, putNext)
       }
     }
 
-    putNext()
+    putNext(null)
   }
 
   _importCookiesSync(serialized: unknown): void {
@@ -980,7 +980,7 @@ export class CookieJar {
       let completedCount = 0
       const removeErrors: Error[] = []
 
-      function removeCookieCb(removeErr: Error | undefined) {
+      function removeCookieCb(removeErr: Error | null) {
         if (removeErr) {
           removeErrors.push(removeErr)
         }
@@ -988,7 +988,7 @@ export class CookieJar {
         completedCount++
 
         if (completedCount === cookies?.length) {
-          cb(removeErrors.length ? removeErrors[0] : null)
+          cb(removeErrors[0] ?? null)
           return
         }
       }
@@ -1083,7 +1083,7 @@ export class CookieJar {
         promiseCallback.callback(err)
         return
       }
-      promiseCallback.callback(undefined, jar)
+      promiseCallback.callback(null, jar)
     })
 
     return promiseCallback.promise

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -216,9 +216,13 @@ export class CookieJar {
   setCookie(
     cookie: string | Cookie,
     url: string,
-    options?: SetCookieOptions | Callback<Cookie>,
+    options?: SetCookieOptions | Callback<Cookie | undefined>,
     callback?: Callback<Cookie | undefined>,
   ): unknown {
+    if (typeof options === 'function') {
+      callback = options
+      options = undefined
+    }
     const promiseCallback = createPromiseCallback(callback)
     const cb = promiseCallback.callback
 
@@ -520,16 +524,19 @@ export class CookieJar {
     options?: GetCookiesOptions | Callback<Cookie[]>,
     callback?: Callback<Cookie[]>,
   ): unknown {
+    if (typeof options === 'function') {
+      callback = options
+      options = defaultGetCookieOptions
+    } else if (options === undefined) {
+      options = defaultGetCookieOptions
+    }
     const promiseCallback = createPromiseCallback(callback)
     const cb = promiseCallback.callback
 
     validators.validate(validators.isNonEmptyString(url), cb, url)
-    const context = getCookieContext(url)
-    if (typeof options === 'function' || options === undefined) {
-      options = defaultGetCookieOptions
-    }
     validators.validate(validators.isObject(options), cb, safeToString(options))
     validators.validate(typeof cb === 'function', cb)
+    const context = getCookieContext(url)
 
     const host = canonicalDomain(context.hostname)
     const path = context.pathname || '/'
@@ -678,12 +685,11 @@ export class CookieJar {
     options?: GetCookiesOptions | Callback<string | undefined>,
     callback?: Callback<string | undefined>,
   ): unknown {
-    const promiseCallback = createPromiseCallback(callback)
-
     if (typeof options === 'function') {
+      callback = options
       options = undefined
     }
-
+    const promiseCallback = createPromiseCallback(callback)
     const next: Callback<Cookie[]> = function (
       err: Error | null,
       cookies: Cookie[] | undefined,
@@ -691,7 +697,7 @@ export class CookieJar {
       if (err) {
         promiseCallback.callback(err)
       } else if (cookies === undefined) {
-        promiseCallback.callback(null, undefined)
+        promiseCallback.callback(null, cookies)
       } else {
         promiseCallback.callback(
           null,
@@ -738,13 +744,13 @@ export class CookieJar {
     options?: GetCookiesOptions | Callback<string[] | undefined>,
     callback?: Callback<string[] | undefined>,
   ): unknown {
+    if (typeof options === 'function') {
+      callback = options
+      options = undefined
+    }
     const promiseCallback = createPromiseCallback<string[] | undefined>(
       callback,
     )
-
-    if (typeof options === 'function') {
-      options = undefined
-    }
 
     const next: Callback<Cookie[]> = function (
       err: Error | null,
@@ -780,7 +786,6 @@ export class CookieJar {
 
   serialize(callback: Callback<SerializedCookieJar>): void
   serialize(): Promise<SerializedCookieJar>
-  serialize(callback?: Callback<SerializedCookieJar>): unknown
   serialize(callback?: Callback<SerializedCookieJar>): unknown {
     const promiseCallback = createPromiseCallback<SerializedCookieJar>(callback)
     const cb = promiseCallback.callback
@@ -923,6 +928,7 @@ export class CookieJar {
     callback?: Callback<CookieJar>,
   ): unknown {
     if (typeof newStore === 'function') {
+      callback = newStore
       newStore = undefined
     }
 
@@ -961,7 +967,6 @@ export class CookieJar {
 
   removeAllCookies(callback: Callback<void>): void
   removeAllCookies(): Promise<void>
-  removeAllCookies(callback?: Callback<void>): unknown
   removeAllCookies(callback?: Callback<void>): unknown {
     const promiseCallback = createPromiseCallback<void>(callback)
     const cb = promiseCallback.callback
@@ -1052,6 +1057,7 @@ export class CookieJar {
     callback?: Callback<CookieJar>,
   ): unknown {
     if (typeof store === 'function') {
+      callback = store
       store = undefined
     }
 

--- a/lib/memstore.ts
+++ b/lib/memstore.ts
@@ -83,10 +83,9 @@ export class MemoryCookieStore extends Store {
     domain: string | null,
     path: string | null,
     key: string | undefined,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _callback?: Callback<Cookie | null | undefined>,
+    callback?: Callback<Cookie | null | undefined>,
   ): unknown {
-    const promiseCallback = createPromiseCallback(arguments)
+    const promiseCallback = createPromiseCallback(callback)
     const cb = promiseCallback.callback
 
     if (domain == null || path == null) {
@@ -126,15 +125,14 @@ export class MemoryCookieStore extends Store {
     domain: string,
     path: string,
     allowSpecialUseDomain: boolean | Callback<Cookie[]> = false,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _callback?: Callback<Cookie[]>,
+    callback?: Callback<Cookie[]>,
   ): unknown {
     if (typeof allowSpecialUseDomain === 'function') {
       allowSpecialUseDomain = true
     }
 
     const results: Cookie[] = []
-    const promiseCallback = createPromiseCallback<Cookie[]>(arguments)
+    const promiseCallback = createPromiseCallback<Cookie[]>(callback)
     const cb = promiseCallback.callback
 
     if (!domain) {
@@ -191,9 +189,8 @@ export class MemoryCookieStore extends Store {
 
   override putCookie(cookie: Cookie): Promise<void>
   override putCookie(cookie: Cookie, callback: Callback<void>): void
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  override putCookie(cookie: Cookie, _callback?: Callback<void>): unknown {
-    const promiseCallback = createPromiseCallback<void>(arguments)
+  override putCookie(cookie: Cookie, callback?: Callback<void>): unknown {
+    const promiseCallback = createPromiseCallback<void>(callback)
     const cb = promiseCallback.callback
 
     const { domain, path, key } = cookie
@@ -257,10 +254,9 @@ export class MemoryCookieStore extends Store {
     domain: string,
     path: string,
     key: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _callback?: Callback<void>,
+    callback?: Callback<void>,
   ): unknown {
-    const promiseCallback = createPromiseCallback<void>(arguments)
+    const promiseCallback = createPromiseCallback<void>(callback)
     const cb = promiseCallback.callback
 
     const domainEntry = this.idx[domain]
@@ -287,10 +283,9 @@ export class MemoryCookieStore extends Store {
   override removeCookies(
     domain: string,
     path: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _callback?: Callback<void>,
+    callback?: Callback<void>,
   ): unknown {
-    const promiseCallback = createPromiseCallback<void>(arguments)
+    const promiseCallback = createPromiseCallback<void>(callback)
     const cb = promiseCallback.callback
 
     const domainEntry = this.idx[domain]
@@ -308,9 +303,8 @@ export class MemoryCookieStore extends Store {
 
   override removeAllCookies(): Promise<void>
   override removeAllCookies(callback: Callback<void>): void
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  override removeAllCookies(_callback?: Callback<void>): unknown {
-    const promiseCallback = createPromiseCallback<void>(arguments)
+  override removeAllCookies(callback?: Callback<void>): unknown {
+    const promiseCallback = createPromiseCallback<void>(callback)
     const cb = promiseCallback.callback
 
     this.idx = Object.create(null) as MemoryCookieStoreIndex
@@ -321,9 +315,8 @@ export class MemoryCookieStore extends Store {
 
   override getAllCookies(): Promise<Cookie[]>
   override getAllCookies(callback: Callback<Cookie[]>): void
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  override getAllCookies(_callback?: Callback<Cookie[]>): unknown {
-    const promiseCallback = createPromiseCallback<Cookie[]>(arguments)
+  override getAllCookies(callback?: Callback<Cookie[]>): unknown {
+    const promiseCallback = createPromiseCallback<Cookie[]>(callback)
     const cb = promiseCallback.callback
 
     const cookies: Cookie[] = []

--- a/lib/memstore.ts
+++ b/lib/memstore.ts
@@ -72,42 +72,25 @@ export class MemoryCookieStore extends Store {
     domain: string | null,
     path: string | null,
     key: string | undefined,
-  ): Promise<Cookie | null | undefined>
+  ): Promise<Cookie | undefined>
   override findCookie(
     domain: string | null,
     path: string | null,
     key: string | undefined,
-    callback: Callback<Cookie | null | undefined>,
+    callback: Callback<Cookie | undefined>,
   ): void
   override findCookie(
     domain: string | null,
     path: string | null,
     key: string | undefined,
-    callback?: Callback<Cookie | null | undefined>,
+    callback?: Callback<Cookie | undefined>,
   ): unknown {
     const promiseCallback = createPromiseCallback(callback)
-    const cb = promiseCallback.callback
-
-    if (domain == null || path == null) {
+    if (domain == null || path == null || key == null) {
       return promiseCallback.resolve(undefined)
     }
-
-    const domainEntry = this.idx[domain]
-    if (!domainEntry) {
-      return promiseCallback.resolve(undefined)
-    }
-
-    const pathEntry = domainEntry[path]
-    if (!pathEntry) {
-      return promiseCallback.resolve(undefined)
-    }
-
-    if (key == null) {
-      return promiseCallback.resolve(null)
-    }
-
-    cb(null, pathEntry[key] || null)
-    return promiseCallback.promise
+    const result = this.idx?.[domain]?.[path]?.[key]
+    return promiseCallback.resolve(result)
   }
 
   override findCookies(

--- a/lib/memstore.ts
+++ b/lib/memstore.ts
@@ -128,6 +128,9 @@ export class MemoryCookieStore extends Store {
     callback?: Callback<Cookie[]>,
   ): unknown {
     if (typeof allowSpecialUseDomain === 'function') {
+      callback = allowSpecialUseDomain
+      // TODO: It's weird that `allowSpecialUseDomain` defaults to false with no callback,
+      // but true with a callback. This is legacy behavior from v4.
       allowSpecialUseDomain = true
     }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,11 +1,8 @@
-/** A callback function that expects an error to be passed. */
-export type ErrorCallback = (error: Error, result?: never) => void
-
-/** A callback function that expects a successful result. */
-type SuccessCallback<T> = (error: null, result: T) => void
-
 /** A callback function that accepts an error or a result. */
-export type Callback<T> = SuccessCallback<T> & ErrorCallback
+export interface Callback<T> {
+  (error: Error, result?: never): void
+  (error: null, result: T): void
+}
 
 /** Safely converts any value to string, using the value's own `toString` when available. */
 export const safeToString = (val: unknown) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -27,7 +27,7 @@ export interface PromiseCallback<T> {
 }
 
 /** Converts a callback into a utility object where either a callback or a promise can be used. */
-export function createPromiseCallback<T>(args: IArguments): PromiseCallback<T> {
+export function createPromiseCallback<T>(cb?: Callback<T>): PromiseCallback<T> {
   let callback: Callback<T>
   let resolve: (result: T) => void
   let reject: (error: Error) => void
@@ -37,11 +37,14 @@ export function createPromiseCallback<T>(args: IArguments): PromiseCallback<T> {
     reject = _reject
   })
 
-  const cb: unknown = args[args.length - 1]
   if (typeof cb === 'function') {
     callback = (err, result) => {
       try {
-        cb(err, result)
+        if (err) cb(err)
+        // If `err` is null, we know `result` must be `T`
+        // The assertion isn't *strictly* correct, as `T` could be nullish, but, ehh, good enough...
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        else cb(null, result!)
       } catch (e) {
         reject(e instanceof Error ? e : new Error())
       }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,6 +4,10 @@ export interface Callback<T> {
   (error: null, result: T): void
 }
 
+/** Wrapped `Object.prototype.toString`, so that you don't need to remember to use `.call()`. */
+export const objectToString = (obj: unknown) =>
+  Object.prototype.toString.call(obj)
+
 /** Safely converts any value to string, using the value's own `toString` when available. */
 export const safeToString = (val: unknown) => {
   // Ideally, we'd just use String() for everything, but it breaks if `toString` is missing (mostly
@@ -11,7 +15,7 @@ export const safeToString = (val: unknown) => {
   if (val === undefined || val === null || typeof val.toString === 'function') {
     return String(val)
   } else {
-    return Object.prototype.toString.call(val)
+    return objectToString(val)
   }
 }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,5 @@
 /** A callback function that accepts an error or a result. */
-export type Callback<T> = (
-  error: Error | undefined,
-  result: T | undefined,
-) => void
+export type Callback<T> = (error: Error | null, result: T | undefined) => void
 
 /** Signature for a callback function that expects an error to be passed. */
 export type ErrorCallback = (error: Error, result?: never) => void
@@ -25,9 +22,9 @@ export const safeToString = (val: unknown) => {
 /** Utility object for promise/callback interop. */
 export interface PromiseCallback<T> {
   promise: Promise<T | undefined>
-  callback: (error: Error | undefined | null, result?: T) => void
+  callback: (error: Error | null, result?: T) => void
   resolve: (value: T | undefined) => Promise<T | undefined>
-  reject: (error: Error | undefined | null) => Promise<T | undefined>
+  reject: (error: Error | null) => Promise<T | undefined>
 }
 
 /** Converts a callback into a utility object where either a callback or a promise can be used. */

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,8 +1,11 @@
-/** A callback function that accepts an error or a result. */
-export type Callback<T> = (error: Error | null, result: T | undefined) => void
+/** A callback function that expects an error to be passed. */
+export type ErrorCallback<Err = Error> = (error: Err, result?: never) => void
 
-/** Signature for a callback function that expects an error to be passed. */
-export type ErrorCallback = (error: Error, result?: never) => void
+/** A callback function that expects a successful result. */
+type SuccessCallback<T> = (error: null, result: T) => void
+
+/** A callback function that accepts an error or a result. */
+export type Callback<T, Err = Error> = SuccessCallback<T> & ErrorCallback<Err>
 
 /** Safely converts any value to string, using the value's own `toString` when available. */
 export const safeToString = (val: unknown) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,10 +4,6 @@ export type Callback<T> = (error: Error | null, result: T | undefined) => void
 /** Signature for a callback function that expects an error to be passed. */
 export type ErrorCallback = (error: Error, result?: never) => void
 
-/** Wrapped `Object.prototype.toString`, so that you don't need to remember to use `.call()`. */
-export const objectToString = (obj: unknown) =>
-  Object.prototype.toString.call(obj)
-
 /** Safely converts any value to string, using the value's own `toString` when available. */
 export const safeToString = (val: unknown) => {
   // Ideally, we'd just use String() for everything, but it breaks if `toString` is missing (mostly
@@ -15,7 +11,7 @@ export const safeToString = (val: unknown) => {
   if (val === undefined || val === null || typeof val.toString === 'function') {
     return String(val)
   } else {
-    return objectToString(val)
+    return Object.prototype.toString.call(val)
   }
 }
 

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -26,7 +26,7 @@ SOFTWARE.
 
 ************************************************************************************ */
 
-import { ErrorCallback, safeToString } from './utils'
+import { Callback, safeToString } from './utils'
 
 /* Validation functions copied from check-types package - https://www.npmjs.com/package/check-types */
 
@@ -68,7 +68,7 @@ export function isInteger(data: unknown): boolean {
  */
 export function validate(
   bool: boolean,
-  cbOrMessage?: ErrorCallback | string,
+  cbOrMessage?: Callback<never> | string,
   message?: string,
 ): void {
   if (bool) return // Validation passes

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -26,7 +26,7 @@ SOFTWARE.
 
 ************************************************************************************ */
 
-import { ErrorCallback, objectToString, safeToString } from './utils'
+import { ErrorCallback, safeToString } from './utils'
 
 /* Validation functions copied from check-types package - https://www.npmjs.com/package/check-types */
 
@@ -52,7 +52,7 @@ export function isString(data: unknown): boolean {
 
 /** Determines whether the string representation of the argument is "[object Object]". */
 export function isObject(data: unknown): boolean {
-  return objectToString(data) === '[object Object]'
+  return safeToString(data) === '[object Object]'
 }
 
 /** Determines whether the argument is an integer. */

--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -26,7 +26,7 @@ SOFTWARE.
 
 ************************************************************************************ */
 
-import { Callback, safeToString } from './utils'
+import { Callback, objectToString, safeToString } from './utils'
 
 /* Validation functions copied from check-types package - https://www.npmjs.com/package/check-types */
 
@@ -52,7 +52,7 @@ export function isString(data: unknown): boolean {
 
 /** Determines whether the string representation of the argument is "[object Object]". */
 export function isObject(data: unknown): boolean {
-  return safeToString(data) === '[object Object]'
+  return objectToString(data) === '[object Object]'
 }
 
 /** Determines whether the argument is an integer. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,9 @@
     /* Compatibility */
     "ignoreDeprecations": "5.0"
   },
+  "include": [
+    "lib"
+  ],
   "exclude": [
     "jest.config.ts"
   ]


### PR DESCRIPTION
Using `arguments` is a known code smell. It is used by `createPromiseCallback` to extract the callback from the last provided argument. However, all calling code already knows which variable contains the callback, so we don't actually need to use `arguments`.