### PR TITLE
Replace `psl` with `tldts`

### DIFF
--- a/lib/cookie/cookie.ts
+++ b/lib/cookie/cookie.ts
@@ -32,7 +32,7 @@
 // This file was too big before we added max-lines, and it's ongoing work to reduce its size.
 /* eslint max-lines: [1, 750] */
 
-import * as pubsuffix from '../pubsuffix-psl'
+import { getPublicSuffix } from '../getPublicSuffix'
 import * as validators from '../validators'
 import { getCustomInspectSymbol } from '../utilHelper'
 import { inOperator } from '../utils'
@@ -559,7 +559,7 @@ export class Cookie {
       if (cdomain.match(/\.$/)) {
         return false // S4.1.2.3 suggests that this is bad. domainMatch() tests confirm this
       }
-      const suffix = pubsuffix.getPublicSuffix(cdomain)
+      const suffix = getPublicSuffix(cdomain)
       if (suffix == null) {
         // it's a public suffix
         return false

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -1,6 +1,6 @@
 import urlParse from 'url-parse'
 
-import * as pubsuffix from '../pubsuffix-psl'
+import { getPublicSuffix } from '../getPublicSuffix'
 import * as validators from '../validators'
 import { Store } from '../store'
 import { MemoryCookieStore } from '../memstore'
@@ -298,7 +298,7 @@ export class CookieJar {
         const cdomain = cookie.cdomain()
         const suffix =
           typeof cdomain === 'string'
-            ? pubsuffix.getPublicSuffix(cdomain, {
+            ? getPublicSuffix(cdomain, {
                 allowSpecialUseDomain: this.allowSpecialUseDomain,
                 ignoreError: options?.ignoreError,
               })

--- a/lib/cookie/index.ts
+++ b/lib/cookie/index.ts
@@ -1,7 +1,7 @@
 export { MemoryCookieStore } from '../memstore'
 export { pathMatch } from '../pathMatch'
 export { permuteDomain } from '../permuteDomain'
-export { getPublicSuffix } from '../pubsuffix-psl'
+export { getPublicSuffix } from '../getPublicSuffix'
 export { Store } from '../store'
 export { ParameterError } from '../validators'
 export { version } from '../version'
@@ -18,4 +18,5 @@ export { parseDate } from './parseDate'
 export { permutePath } from './permutePath'
 
 import { Cookie } from './cookie'
+
 export const fromJSON = Cookie.fromJSON

--- a/lib/getPublicSuffix.ts
+++ b/lib/getPublicSuffix.ts
@@ -84,5 +84,8 @@ export function getPublicSuffix(
     )
   }
 
-  return getDomain(domain)
+  return getDomain(domain, {
+    allowIcannDomains: true,
+    allowPrivateDomains: true,
+  })
 }

--- a/lib/permuteDomain.ts
+++ b/lib/permuteDomain.ts
@@ -29,7 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict'
-import { getPublicSuffix } from './pubsuffix-psl'
+import { getPublicSuffix } from './getPublicSuffix'
 
 // Gives the permutation of all possible domainMatch()es of a given domain. The
 // array is in shortest-to-longest order.  Handy for indexing.

--- a/lib/pubsuffix-psl.ts
+++ b/lib/pubsuffix-psl.ts
@@ -29,7 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 'use strict'
-import * as psl from 'psl'
+import { getDomain } from 'tldts'
 
 // RFC 6761
 const SPECIAL_USE_DOMAINS = ['local', 'example', 'invalid', 'localhost', 'test']
@@ -84,5 +84,5 @@ export function getPublicSuffix(
     )
   }
 
-  return psl.get(domain)
+  return getDomain(domain)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "5.0.0-rc.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "psl": "^1.9.0",
         "punycode": "^2.3.1",
         "tldts": "^6.1.0",
         "url-parse": "^1.5.10"
@@ -6201,11 +6200,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -11592,11 +11586,6 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
-    },
-    "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "psl": "^1.9.0",
         "punycode": "^2.3.1",
+        "tldts": "^6.1.0",
         "url-parse": "^1.5.10"
       },
       "devDependencies": {
@@ -6628,6 +6629,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.0.tgz",
+      "integrity": "sha512-9eh9oPefds2M+Trcgpa4gLaHtckcmfgHsNwQKE4kfiy6ApJrt4Thko2CXQ9s3K1o0rQtJOLmV0UfFLhC9CAN3w==",
+      "dependencies": {
+        "tldts-core": "^6.1.0"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.0.tgz",
+      "integrity": "sha512-kWIs6ECYvpsHXmVezsbU2ZmaPZld6bArFUM2HS/Pz1o1pRCu/y8w6n02IfiefUA5NarwJ7sCjwsrKGtpztXYZQ=="
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11866,6 +11883,19 @@
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
       "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
       "dev": true
+    },
+    "tldts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.0.tgz",
+      "integrity": "sha512-9eh9oPefds2M+Trcgpa4gLaHtckcmfgHsNwQKE4kfiy6ApJrt4Thko2CXQ9s3K1o0rQtJOLmV0UfFLhC9CAN3w==",
+      "requires": {
+        "tldts-core": "^6.1.0"
+      }
+    },
+    "tldts-core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.0.tgz",
+      "integrity": "sha512-kWIs6ECYvpsHXmVezsbU2ZmaPZld6bArFUM2HS/Pz1o1pRCu/y8w6n02IfiefUA5NarwJ7sCjwsrKGtpztXYZQ=="
     },
     "tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "vows": "^0.8.3"
   },
   "dependencies": {
-    "psl": "^1.9.0",
+    "tldts": "^6.1.0",
     "punycode": "^2.3.1",
     "url-parse": "^1.5.10"
   }


### PR DESCRIPTION
One of the topics that came up in discussions for v5 was considering replacements for `psl` (see https://github.com/salesforce/tough-cookie/discussions/255). This PR replaces that library with `tldts` which is more performant.

Fixes #239
Fixes #338