### PR TITLE
Handle unlikely edge case in unimportant util

### DIFF
--- a/lib/__tests__/util.spec.ts
+++ b/lib/__tests__/util.spec.ts
@@ -1,0 +1,28 @@
+import { safeToString } from '../utils'
+
+describe('safeToString', () => {
+  const basic = [
+    undefined,
+    null,
+    true,
+    'string',
+    123,
+    321n,
+    { object: 'yes' },
+    [1, 'hello', true, null],
+    (a: number, b: number) => a + b,
+    Symbol('safeToString'),
+  ]
+  const testCases = [
+    ...basic.map((input) => [input, String(input)]),
+    [Object.create(null), '[object Object]'],
+    [
+      [Object.create(null), Symbol('safeToString')],
+      '[object Object],Symbol("safeToString")',
+    ],
+  ]
+
+  it.each(testCases)('works on %s', (input, output) => {
+    expect(safeToString(input)).toBe(String(output))
+  })
+})

--- a/lib/__tests__/util.spec.ts
+++ b/lib/__tests__/util.spec.ts
@@ -18,7 +18,7 @@ describe('safeToString', () => {
     [Object.create(null), '[object Object]'],
     [
       [Object.create(null), Symbol('safeToString')],
-      '[object Object],Symbol("safeToString")',
+      '[object Object],Symbol(safeToString)',
     ],
   ]
 

--- a/lib/__tests__/util.spec.ts
+++ b/lib/__tests__/util.spec.ts
@@ -1,25 +1,26 @@
 import { safeToString } from '../utils'
 
 describe('safeToString', () => {
-  const basic = [
-    undefined,
-    null,
-    true,
-    'string',
-    123,
-    321n,
-    { object: 'yes' },
-    [1, 'hello', true, null],
-    (a: number, b: number) => a + b,
-    Symbol('safeToString'),
-  ]
+  const recursiveArray: unknown[] = [1]
+  recursiveArray.push([[recursiveArray], 2, [[recursiveArray]]], 3)
   const testCases = [
-    ...basic.map((input) => [input, String(input)]),
+    [undefined, 'undefined'],
+    [null, 'null'],
+    [true, 'true'],
+    ['string', 'string'],
+    [123, '123'],
+    [321n, '321'],
+    [{ object: 'yes' }, '[object Object]'],
+    [(a: number, b: number) => a + b, '(a, b) => a + b'],
+    [Symbol('safeToString'), 'Symbol(safeToString)'],
     [Object.create(null), '[object Object]'],
+    // eslint-disable-next-line no-sparse-arrays
+    [[1, 'hello', , undefined, , true, null], '1,hello,,,,true,'],
     [
       [Object.create(null), Symbol('safeToString')],
       '[object Object],Symbol(safeToString)',
     ],
+    [recursiveArray, '1,,2,,3'],
   ]
 
   it.each(testCases)('works on %s', (input, output) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -18,10 +18,8 @@ export const safeToString = (val: unknown): string => {
   // Using .toString() fails for null/undefined and implicit conversion (val + "") fails for symbols
   // and objects with null prototype
   if (val === undefined || val === null || typeof val.toString === 'function') {
-    return String(val)
-  } else if (Array.isArray(val)) {
     // Array#toString implicitly converts its values to strings, which is what we're trying to avoid
-    return val.map(safeToString).join()
+    return Array.isArray(val) ? val.map(safeToString).join() : String(val)
   } else {
     // This case should just be objects with null prototype, so we can just use Object#toString
     return objectToString(val)

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -14,12 +14,16 @@ export const objectToString = (obj: unknown) =>
   Object.prototype.toString.call(obj)
 
 /** Safely converts any value to string, using the value's own `toString` when available. */
-export const safeToString = (val: unknown) => {
-  // Ideally, we'd just use String() for everything, but it breaks if `toString` is missing (mostly
-  // values with no prototype), so we have to use Object#toString as a fallback.
+export const safeToString = (val: unknown): string => {
+  // Using .toString() fails for null/undefined and implicit conversion (val + "") fails for symbols
+  // and objects with null prototype
   if (val === undefined || val === null || typeof val.toString === 'function') {
     return String(val)
+  } else if (Array.isArray(val)) {
+    // Array#toString implicitly converts its values to strings, which is what we're trying to avoid
+    return val.map(safeToString).join()
   } else {
+    // This case should just be objects with null prototype, so we can just use Object#toString
     return objectToString(val)
   }
 }


### PR DESCRIPTION
Currently `safeToString([Object.create(null)])` throws, even though it shouldn't. This PR fixes that.