### PR TITLE
Remove community cookie store links

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,16 +470,6 @@ Inherits from `Store`.
 
 A just-in-memory CookieJar synchronous store implementation, used by default. Despite being a synchronous implementation, it's usable with both the synchronous and asynchronous forms of the `CookieJar` API. Supports serialization, `getAllCookies`, and `removeAllCookies`.
 
-### Community Cookie Stores
-
-These are some Store implementations authored and maintained by the community. They aren't official and we don't vouch for them but you may be interested to have a look:
-
-- [`db-cookie-store`](https://github.com/JSBizon/db-cookie-store): SQL including SQLite-based databases
-- [`file-cookie-store`](https://github.com/JSBizon/file-cookie-store): Netscape cookie file format on disk
-- [`redis-cookie-store`](https://github.com/benkroeger/redis-cookie-store): Redis
-- [`tough-cookie-filestore`](https://github.com/mitsuru/tough-cookie-filestore): JSON on disk
-- [`tough-cookie-web-storage-store`](https://github.com/exponentjs/tough-cookie-web-storage-store): DOM localStorage and sessionStorage
-
 ## Serialization Format
 
 **NOTE**: If you want to have custom `Cookie` properties serialized, add the property name to `Cookie.serializableProperties`.


### PR DESCRIPTION
Many of these community maintained implementations are no longer active or have been replaced by forks. During a maintainers discussion it was proposed that we drop these links from the `README` for the following reasons:
- We don't track these projects closely and cannot vouch for their quality
- Given our limited time and resources, keeping an up-to-date list of community projects is not something we want to commit to maintaining. 

Related #360 
