### PR TITLE
Fix allow listed `files` for what to include in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-docker-compose.yml
-Dockerfile
-.nyc_output
-coverage
-package-lock.json

--- a/package.json
+++ b/package.json
@@ -79,10 +79,9 @@
   "main": "./dist/cookie/index.js",
   "types": "./dist/cookie/index.d.ts",
   "files": [
-    "dist/*.js",
-    "dist/*.d.ts",
-    "dist/cookie/*.js",
-    "dist/cookie/*.d.ts"
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "!__tests__"
   ],
   "scripts": {
     "build": "npm run clean && tsc",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,9 @@
   "types": "./dist/cookie/index.d.ts",
   "files": [
     "dist/*.js",
-    "dist/*.d.ts"
+    "dist/*.d.ts",
+    "dist/cookie/*.js",
+    "dist/cookie/*.d.ts"
   ],
   "scripts": {
     "build": "npm run clean && tsc",


### PR DESCRIPTION
When #296 was merged, the list of files to include in `package.json` was not updated. This PR fixes that.

The `.npmignore` file is also removed because I find it causes some unexpected behaviors like [ignoring the contents of `.gitignore`](https://docs.npmjs.com/cli/v10/using-npm/developers#keeping-files-out-of-your-package). It's a bit of extra work to maintain the allow listed `files` but it's generally safer.

--- 

### Output of `npm pack --dry-run`

```
npm notice 
npm notice 📦  tough-cookie@5.0.0-rc.0
npm notice === Tarball Contents === 
npm notice 1.5kB  LICENSE                       
npm notice 33.7kB README.md                     
npm notice 1.8kB  dist/cookie/canonicalDomain.js
npm notice 1.7kB  dist/cookie/constants.js      
npm notice 23.0kB dist/cookie/cookie.js         
npm notice 2.6kB  dist/cookie/cookieCompare.js  
npm notice 33.9kB dist/cookie/cookieJar.js      
npm notice 1.1kB  dist/cookie/defaultPath.js    
npm notice 3.2kB  dist/cookie/domainMatch.js    
npm notice 1.5kB  dist/cookie/formatDate.js     
npm notice 3.4kB  dist/cookie/index.js          
npm notice 7.5kB  dist/cookie/parseDate.js      
npm notice 1.8kB  dist/cookie/permutePath.js    
npm notice 3.7kB  dist/getPublicSuffix.js       
npm notice 7.7kB  dist/memstore.js              
npm notice 2.6kB  dist/pathMatch.js             
npm notice 2.7kB  dist/permuteDomain.js         
npm notice 3.0kB  dist/store.js                 
npm notice 2.7kB  dist/utils.js                 
npm notice 3.8kB  dist/validators.js            
npm notice 163B   dist/version.js               
npm notice 3.2kB  package.json                  
npm notice === Tarball Details === 
npm notice name:          tough-cookie                            
npm notice version:       5.0.0-rc.0                              
npm notice filename:      tough-cookie-5.0.0-rc.0.tgz             
npm notice package size:  36.1 kB                                 
npm notice unpacked size: 146.6 kB                                
npm notice shasum:        f6dc8ca361edf95fdecc0916ba9efb244ff94c59
npm notice integrity:     sha512-z5QB31nQV8E7F[...]/eHsanozKbjSg==
npm notice total files:   22                                      
npm notice 
tough-cookie-5.0.0-rc.0.tgz
```