### PR TITLE
patch removed util methods for vows

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "version": "genversion --es6 lib/version.ts && git add lib/version.ts",
     "test": "npm run test:ts && npm run test:legacy",
     "test:ts": "jest",
-    "test:legacy": "npm run build -- --declaration false && vows test/*_test.js",
+    "test:legacy": "npm run build -- --declaration false && ./test/scripts/vows.js test/*_test.js",
     "typecheck": "tsc --noEmit",
     "cover": "jest --coverage",
     "eslint": "eslint --env node --ext .ts .",

--- a/test/scripts/vows.js
+++ b/test/scripts/vows.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Vows logs using methods from `util` that were removed in node v12. To avoid cryptic
+ * error messages when tests fail, we patch those methods using `console.log`.
+ * @see {@link https://nodejs.org/api/deprecations.html#DEP0026|`util.print` deprecation}
+ * @see {@link https://nodejs.org/api/deprecations.html#DEP0027|`util.puts` deprecation}
+ * @see {@link https://nodejs.org/docs/latest-v0.10.x/api/util.html|Docs for deprecated `util` methods}
+ */
+
+// Patch deprecated util methods
+const util = require("node:util");
+util.print = (...args) => console.log(args.join(''));
+util.puts = (...args) => console.log(args.join('\n'));
+// Call vows executable
+require("vows/bin/vows");


### PR DESCRIPTION
Vows is a legacy test suite, and we plan on removing it eventually, but in the meantime it would be nice if it actually worked. To see the intended output when tests fail, we need to patch `util.patch` and `util.puts`.