### PR TITLE
Add local alias for `toString`

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -28,6 +28,9 @@ SOFTWARE.
 "use strict";
 
 /* Validation functions copied from check-types package - https://www.npmjs.com/package/check-types */
+
+const toString = Object.prototype.toString;
+
 function isFunction(data) {
   return typeof data === "function";
 }


### PR DESCRIPTION
Set `toString` to `Object.prototype.toString` as the code implicitly expects, to avoid conflicts with mocked globals. (see issue #405).