### PR TITLE
Checks structure instead of instanceof for URL test

### DIFF
--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -188,9 +188,28 @@ export interface CreateCookieJarOptions {
 const SAME_SITE_CONTEXT_VAL_ERR =
   'Invalid sameSiteContext option for getCookies(); expected one of "strict", "lax", or "none"'
 
-function getCookieContext(url: unknown): URL {
-  if (url instanceof URL) {
-    return url
+type UrlContext = {
+  hostname: string
+  pathname: string
+  protocol: string
+}
+
+function getCookieContext(url: unknown): UrlContext {
+  if (
+    url &&
+    typeof url === 'object' &&
+    'hostname' in url &&
+    typeof url.hostname === 'string' &&
+    'pathname' in url &&
+    typeof url.pathname === 'string' &&
+    'protocol' in url &&
+    typeof url.protocol === 'string'
+  ) {
+    return {
+      hostname: url.hostname,
+      pathname: url.pathname,
+      protocol: url.protocol,
+    }
   } else if (typeof url === 'string') {
     try {
       return new URL(decodeURI(url))
@@ -435,7 +454,7 @@ export class CookieJar {
     }
     const promiseCallback = createPromiseCallback(callback)
     const cb = promiseCallback.callback
-    let context: URL
+    let context: UrlContext
 
     try {
       if (typeof url === 'string') {
@@ -819,7 +838,7 @@ export class CookieJar {
     }
     const promiseCallback = createPromiseCallback(callback)
     const cb = promiseCallback.callback
-    let context: URL
+    let context: UrlContext
 
     try {
       if (typeof url === 'string') {


### PR DESCRIPTION
This is a follow up into my testing of our latest release candidate against the `jsdom` test suite. The callback issues have been sorted out but I also encountered a validation issue around the `URL` object that is used by `jsdom`. When we are passed a `URL` object, we test it using `url instanceof URL` but the `URL` object from `jsdom` is not the same as the global `URL` object. 

Relying on `instanceof` is always tricky in JavaScript. We should instead favor checking for the structure of the object we expect which must have the following structure:

```ts
type UrlContext = {
  hostname: string
  pathname: string
  protocol: string
}
```

This PR replaces the `instanceof` check with a validation for the above structure. This will pass for unknown `url` values that are instances of `URL` since they will have that structure and is already represented by the following test:
https://github.com/salesforce/tough-cookie/blob/master/lib/__tests__/cookieJar.spec.ts#L1252-L1265