### PR TITLE
Enable isolated declarations

### DIFF
--- a/lib/__tests__/data/dates/bsd-examples.ts
+++ b/lib/__tests__/data/dates/bsd-examples.ts
@@ -219,4 +219,4 @@ export default [
     test: 'IAintNoDateFool',
     expected: null,
   },
-]
+] as const

--- a/lib/__tests__/data/dates/examples.ts
+++ b/lib/__tests__/data/dates/examples.ts
@@ -59,4 +59,4 @@ export default [
     test: 'Thu, 10 Dec 2009 13:57:2 GMT',
     expected: 'Thu, 10 Dec 2009 13:57:02 GMT',
   },
-]
+] as const

--- a/lib/__tests__/data/parser.ts
+++ b/lib/__tests__/data/parser.ts
@@ -1330,4 +1330,4 @@ export default [
     received: ['\tfoo\t=\tbar\t \t;\tttt'],
     sent: [{ name: 'foo', value: 'bar' }],
   },
-]
+] as const

--- a/lib/__tests__/ietf.spec.ts
+++ b/lib/__tests__/ietf.spec.ts
@@ -42,9 +42,10 @@ describe('IETF http state tests', () => {
       const jar = new CookieJar()
       const expected = testCase.sent
       const sentFrom = `http://home.example.org/cookie-parser?${testCase.test}`
-      const sentTo = testCase['sent-to']
-        ? url.resolve('http://home.example.org', testCase['sent-to'])
-        : `http://home.example.org/cookie-parser-result?${testCase.test}`
+      const sentTo =
+        'sent-to' in testCase
+          ? url.resolve('http://home.example.org', testCase['sent-to'])
+          : `http://home.example.org/cookie-parser-result?${testCase.test}`
 
       testCase['received'].forEach((cookieStr) => {
         jar.setCookieSync(cookieStr, sentFrom, { ignoreError: true })

--- a/lib/cookie/constants.ts
+++ b/lib/cookie/constants.ts
@@ -11,7 +11,11 @@
  * - `unsafe-disabled` - Disables cookie prefix checking.
  * @public
  */
-export const PrefixSecurityEnum = Object.freeze({
+export const PrefixSecurityEnum: {
+  readonly SILENT: 'silent'
+  readonly STRICT: 'strict'
+  readonly DISABLED: 'unsafe-disabled'
+} = Object.freeze({
   SILENT: 'silent',
   STRICT: 'strict',
   DISABLED: 'unsafe-disabled',
@@ -32,7 +36,7 @@ const IP_V6_REGEX = `
   .replace(/\s*\/\/.*$/gm, '')
   .replace(/\n/g, '')
   .trim()
-export const IP_V6_REGEX_OBJECT = new RegExp(`^${IP_V6_REGEX}$`)
+export const IP_V6_REGEX_OBJECT: RegExp = new RegExp(`^${IP_V6_REGEX}$`)
 
 /**
  * A JSON representation of a {@link CookieJar}.

--- a/lib/cookie/cookie.ts
+++ b/lib/cookie/cookie.ts
@@ -545,20 +545,6 @@ export class Cookie {
     this.creationIndex = Cookie.cookiesCreated
   }
 
-  [Symbol.for('nodejs.util.inspect.custom')](): string {
-    const now = Date.now()
-    const hostOnly = this.hostOnly != null ? this.hostOnly.toString() : '?'
-    const createAge =
-      this.creation && this.creation !== 'Infinity'
-        ? `${String(now - this.creation.getTime())}ms`
-        : '?'
-    const accessAge =
-      this.lastAccessed && this.lastAccessed !== 'Infinity'
-        ? `${String(now - this.lastAccessed.getTime())}ms`
-        : '?'
-    return `Cookie="${this.toString()}; hostOnly=${hostOnly}; aAge=${accessAge}; cAge=${createAge}"`
-  }
-
   /**
    * For convenience in using `JSON.stringify(cookie)`. Returns a plain-old Object that can be JSON-serialized.
    *
@@ -986,4 +972,24 @@ export class Cookie {
     'lastAccessed',
     'sameSite',
   ] as const
+}
+
+// Using TypeScript's isolated declarations mode means we can't use computed properties.
+// Creating this method outside the class means that it's not visible to TypeScript code,
+// even though it is present at runtime. That's probably fine, because this is a low-level
+// detail that we don't expect users to be calling directly.
+;(Cookie.prototype as unknown as Record<symbol, unknown>)[
+  Symbol.for('nodejs.util.inspect.custom')
+] = function inspect(this: Cookie): string {
+  const now = Date.now()
+  const hostOnly = this.hostOnly != null ? this.hostOnly.toString() : '?'
+  const createAge =
+    this.creation && this.creation !== 'Infinity'
+      ? `${String(now - this.creation.getTime())}ms`
+      : '?'
+  const accessAge =
+    this.lastAccessed && this.lastAccessed !== 'Infinity'
+      ? `${String(now - this.lastAccessed.getTime())}ms`
+      : '?'
+  return `Cookie="${this.toString()}; hostOnly=${hostOnly}; aAge=${accessAge}; cAge=${createAge}"`
 }

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "version": "genversion --template version-template.ejs --force lib/version.ts && git add lib/version.ts",
     "test": "npm run test:ts && npm run test:legacy",
     "test:ts": "jest",
-    "test:legacy": "npm run build -- --declaration false && ./test/scripts/vows.js test/*_test.js",
+    "test:legacy": "npm run build -- --isolatedDeclarations false --declaration false && ./test/scripts/vows.js test/*_test.js",
     "typecheck": "tsc --noEmit",
     "cover": "jest --coverage",
     "lint": "eslint .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": true,
     "isolatedDeclarations": true,
     "outDir": "./dist/",
-    "importsNotUsedAsValues": "error",
+    "verbatimModuleSyntax": false,
     /* Interop Constraints */
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -25,9 +25,7 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "allowUnusedLabels": false,
-    "allowUnreachableCode": false,
-    /* Compatibility */
-    "ignoreDeprecations": "5.0"
+    "allowUnreachableCode": false
   },
   "include": ["lib"],
   "exclude": ["jest.config.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "rootDir": "./lib/",
     /* Emit */
     "declaration": true,
+    "isolatedDeclarations": true,
     "outDir": "./dist/",
     "importsNotUsedAsValues": "error",
     /* Interop Constraints */


### PR DESCRIPTION
I recently learned about [isolated declarations](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations), which enforces some rules on type definitions that make it easier for downstream tooling to get type information without running a full type check. In order to do this, we have to slightly hide our custom inspect function.

I also switched us from `importsNotUsedAsValues` to `verbatimModuleSyntax` because the former is deprecated in favor of the latter.