### PR TITLE
fix: remove cookies that expire at epoch time of `0`

### DIFF
--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -1521,6 +1521,16 @@ describe('validation errors invoke callbacks', () => {
   })
 })
 
+it('issue #455 - should expire a cookie with epoch zero', async () => {
+  const cookieJar = new CookieJar()
+  await cookieJar.setCookie(
+    'OptionsTest=FooBar; Expires=Thu, 01 Jan 1970 00:00:00 GMT;',
+    'http://example.com',
+  )
+  const cookies = await cookieJar.getCookies('http://example.com')
+  expect(cookies.length).toBe(0)
+})
+
 function createCookie(
   cookieString: string,
   options: {

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -937,7 +937,7 @@ export class CookieJar {
       // deferred from S5.3
       // non-RFC: allow retention of expired cookies by choice
       const expiryTime = c.expiryTime()
-      if (expireCheck && expiryTime && expiryTime <= now) {
+      if (expireCheck && expiryTime != undefined && expiryTime <= now) {
         store.removeCookie(c.domain, c.path, c.key, () => {}) // result ignored
         return false
       }


### PR DESCRIPTION
The logic for checking and removing expired cookies fails when the cookie has an expiry date set to the epoch time of `0` (i.e.; `Thu, 01 Jan 1970 00:00:00 GMT`). This is because the branch check that triggers cookie removal was testing `expiryTime` which is `falsy` for a value of `0` and that short-circuits the logic.

This PR updates the logic to narrow the type of `expiryTime` from `number | undefined` to `number` using `expiryTime != undefined` which allows the `0` value to proceed to the subsequent condition and trigger the cookie removal.

Fixes #455