### PR TITLE
fix(path-match): avoid parsing path as regex

### DIFF
--- a/lib/pathMatch.ts
+++ b/lib/pathMatch.ts
@@ -31,10 +31,7 @@ export function pathMatch(reqPath: string, cookiePath: string): boolean {
     // " o  The cookie-path is a prefix of the request-path, and the first
     // character of the request-path that is not included in the cookie- path
     // is a %x2F ("/") character."
-    if (
-      new RegExp(`^${cookiePath}`).test(reqPath) &&
-      reqPath[cookiePath.length] === '/'
-    ) {
+    if (reqPath.startsWith(cookiePath) && reqPath[cookiePath.length] === '/') {
       return true
     }
   }


### PR DESCRIPTION
Fixes #464.