### PR TITLE
isolated modules and almost isolated declarations

### DIFF
--- a/lib/__tests__/data/dates/bsd-examples.ts
+++ b/lib/__tests__/data/dates/bsd-examples.ts
@@ -219,4 +219,4 @@ export default [
     test: 'IAintNoDateFool',
     expected: null,
   },
-]
+] as const

--- a/lib/__tests__/data/dates/examples.ts
+++ b/lib/__tests__/data/dates/examples.ts
@@ -59,4 +59,4 @@ export default [
     test: 'Thu, 10 Dec 2009 13:57:2 GMT',
     expected: 'Thu, 10 Dec 2009 13:57:02 GMT',
   },
-]
+] as const

--- a/lib/__tests__/data/parser.ts
+++ b/lib/__tests__/data/parser.ts
@@ -1330,4 +1330,4 @@ export default [
     received: ['\tfoo\t=\tbar\t \t;\tttt'],
     sent: [{ name: 'foo', value: 'bar' }],
   },
-]
+] as const

--- a/lib/__tests__/ietf.spec.ts
+++ b/lib/__tests__/ietf.spec.ts
@@ -42,9 +42,10 @@ describe('IETF http state tests', () => {
       const jar = new CookieJar()
       const expected = testCase.sent
       const sentFrom = `http://home.example.org/cookie-parser?${testCase.test}`
-      const sentTo = testCase['sent-to']
-        ? url.resolve('http://home.example.org', testCase['sent-to'])
-        : `http://home.example.org/cookie-parser-result?${testCase.test}`
+      const sentTo =
+        'sent-to' in testCase
+          ? url.resolve('http://home.example.org', testCase['sent-to'])
+          : `http://home.example.org/cookie-parser-result?${testCase.test}`
 
       testCase['received'].forEach((cookieStr) => {
         jar.setCookieSync(cookieStr, sentFrom, { ignoreError: true })

--- a/lib/cookie/constants.ts
+++ b/lib/cookie/constants.ts
@@ -11,11 +11,12 @@
  * - `unsafe-disabled` - Disables cookie prefix checking.
  * @public
  */
-export const PrefixSecurityEnum = Object.freeze({
+export const PrefixSecurityEnum = {
   SILENT: 'silent',
   STRICT: 'strict',
   DISABLED: 'unsafe-disabled',
-})
+} as const
+Object.freeze(PrefixSecurityEnum)
 
 const IP_V6_REGEX = `
 \\[?(?:
@@ -32,7 +33,7 @@ const IP_V6_REGEX = `
   .replace(/\s*\/\/.*$/gm, '')
   .replace(/\n/g, '')
   .trim()
-export const IP_V6_REGEX_OBJECT = new RegExp(`^${IP_V6_REGEX}$`)
+export const IP_V6_REGEX_OBJECT: RegExp = new RegExp(`^${IP_V6_REGEX}$`)
 
 /**
  * A JSON representation of a {@link CookieJar}.

--- a/lib/cookie/index.ts
+++ b/lib/cookie/index.ts
@@ -1,24 +1,31 @@
-export { MemoryCookieStore, MemoryCookieStoreIndex } from '../memstore'
+export { MemoryCookieStore, type MemoryCookieStoreIndex } from '../memstore'
 export { pathMatch } from '../pathMatch'
 export { permuteDomain } from '../permuteDomain'
-export { getPublicSuffix, GetPublicSuffixOptions } from '../getPublicSuffix'
+export {
+  getPublicSuffix,
+  type GetPublicSuffixOptions,
+} from '../getPublicSuffix'
 export { Store } from '../store'
 export { ParameterError } from '../validators'
 export { version } from '../version'
-export { Callback, ErrorCallback, Nullable } from '../utils'
+export { type Callback, type ErrorCallback, type Nullable } from '../utils'
 export { canonicalDomain } from './canonicalDomain'
 export {
   PrefixSecurityEnum,
-  SerializedCookie,
-  SerializedCookieJar,
+  type SerializedCookie,
+  type SerializedCookieJar,
 } from './constants'
-export { Cookie, CreateCookieOptions, ParseCookieOptions } from './cookie'
+export {
+  Cookie,
+  type CreateCookieOptions,
+  type ParseCookieOptions,
+} from './cookie'
 export { cookieCompare } from './cookieCompare'
 export {
   CookieJar,
-  CreateCookieJarOptions,
-  GetCookiesOptions,
-  SetCookieOptions,
+  type CreateCookieJarOptions,
+  type GetCookiesOptions,
+  type SetCookieOptions,
 } from './cookieJar'
 export { defaultPath } from './defaultPath'
 export { domainMatch } from './domainMatch'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
     /* Compatibility */
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "5.0",
+    "isolatedModules": true
   },
   "include": ["lib"],
   "exclude": ["jest.config.ts"]


### PR DESCRIPTION
[`isolatedModules`](https://www.typescriptlang.org/tsconfig/#isolatedModules) and [`isolatedDeclarations`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations) provide guardrails that help make type checking faster / more portable. We don't actually need the flags enabled for our current build process / target, but it makes the code more portable if we decide to make changes in the future. And the code changes are pretty trivial, so I figured why not.

Note that we can't actually enable the `isolatedDeclarations` flag because we use a symbol as a property key, but I've made all the other changes to be 99% compatible.
https://github.com/salesforce/tough-cookie/blob/8e39ae145dc9b054a1cfbad7172a469c2f317d63/lib/cookie/cookie.ts#L548