### PR TITLE
Fix regression bug in `domainMatch`

### DIFF
--- a/lib/__tests__/domainMatch.spec.ts
+++ b/lib/__tests__/domainMatch.spec.ts
@@ -74,6 +74,9 @@ describe('domainMatch', () => {
     ['🫠.com', 'xn--129h.com', true], // Emoji!
     ['ρһіѕһ.info', 'xn--2xa01ac71bc.info', true], // Greek + Cyrillic characters
     ['猫.cat', 'xn--z7x.cat', true], // Japanese characters
+
+    // domain that needs to be canonicalized
+    ['www.google.com', '.google.com', true],
   ])('domainMatch(%s, %s) => %s', (string, domain, expectedValue) => {
     expect(domainMatch(string, domain)).toBe(expectedValue)
   })

--- a/lib/cookie/domainMatch.ts
+++ b/lib/cookie/domainMatch.ts
@@ -84,7 +84,7 @@ export function domainMatch(
   /* " o All of the following [three] conditions hold:" */
 
   /* "* The domain string is a suffix of the string" */
-  const idx = _str.lastIndexOf(cookieDomain)
+  const idx = _str.lastIndexOf(_domStr)
   if (idx <= 0) {
     return false // it's a non-match (-1) or prefix (0)
   }


### PR DESCRIPTION
The code in `domainMatch` needs to make comparisions using the `_str` and `_domStr` variables as these are canonicalized versions of the `domain` and `cookieDomain` arguments.

One of the comparisions was mistakenly using the `cookieDomain` when it should have been using `_domStr`. This PR closes #499 by using the correct variable for the comparison and adds a test that covers this case to our list of cases for `domainMatch`.