### PR TITLE
Prevent prototype pollution (CVE-2023-26136) in cookie memstore (#283)

### DIFF
--- a/lib/memstore.js
+++ b/lib/memstore.js
@@ -36,7 +36,7 @@ var util = require('util');
 
 function MemoryCookieStore() {
   Store.call(this);
-  this.idx = {};
+  this.idx = Object.create(null);
 }
 util.inherits(MemoryCookieStore, Store);
 exports.MemoryCookieStore = MemoryCookieStore;
@@ -115,10 +115,10 @@ MemoryCookieStore.prototype.findCookies = function(domain, path, cb) {
 
 MemoryCookieStore.prototype.putCookie = function(cookie, cb) {
   if (!this.idx[cookie.domain]) {
-    this.idx[cookie.domain] = {};
+    this.idx[cookie.domain] = Object.create(null);
   }
   if (!this.idx[cookie.domain][cookie.path]) {
-    this.idx[cookie.domain][cookie.path] = {};
+    this.idx[cookie.domain][cookie.path] = Object.create(null);
   }
   this.idx[cookie.domain][cookie.path][cookie.key] = cookie;
   cb(null);

--- a/test/cookie_jar_test.js
+++ b/test/cookie_jar_test.js
@@ -541,4 +541,32 @@ vows
       }
     }
   })
+  .addBatch({
+    // CVE-2023-26136: Prototype pollution via Domain=__proto__
+    "Issue #282 - Prototype pollution (CVE-2023-26136)": {
+      "when setting a cookie with the domain __proto__": {
+        topic: function () {
+          const jar = new tough.CookieJar(undefined, {
+            rejectPublicSuffixes: false
+          });
+          // Attempt prototype pollution via cookie domain '__proto__'
+          jar.setCookieSync(
+            "Slonser=polluted; Domain=__proto__; Path=/notauth",
+            "https://__proto__/admin"
+          );
+          // Set a normal cookie for control
+          jar.setCookieSync(
+            "Auth=Lol; Domain=google.com; Path=/notauth",
+            "https://google.com/"
+          );
+          this.callback();
+        },
+        "results in a cookie that is not affected by the attempted prototype pollution": function () {
+          const pollutedObject = {};
+          // If prototype is polluted, this would return an object
+          assert.strictEqual(pollutedObject["/notauth"], undefined);
+        }
+      }
+    }
+  })  
   .export(module);


### PR DESCRIPTION
All occurrences of new object creation in `memstore.js` have been changed from `{}` (i.e.; `Object.create(Object.prototype)` to `Object.create(null)` so that we are using object instances that do not have a prototype property that can be polluted.
