### PR TITLE
Reverts the check on the Secure attribute when setting a cookie

### DIFF
--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -1171,57 +1171,6 @@ describe('CookieJar', () => {
         jar = new CookieJar(null, { allowSecureOnLocal: false })
       })
 
-      describe('Storing a secure cookie on a non-secure local origin', () => {
-        it('should throw when setting a Secure cookie on http://localhost', async () => {
-          await expect(
-            jar.setCookie(
-              'testLocalhost=abc; Secure; Path=/',
-              'http://localhost/',
-            ),
-          ).rejects.toThrow(
-            'Cookie is Secure but this is not a secure connection',
-          )
-        })
-
-        it('should throw when setting a Secure cookie on http://127.0.0.1', async () => {
-          await expect(
-            jar.setCookie('loopcookie=val; Secure', 'http://127.0.0.1/'),
-          ).rejects.toThrow(
-            'Cookie is Secure but this is not a secure connection',
-          )
-        })
-
-        it('should throw when setting a Secure cookie on http://[::1]', async () => {
-          await expect(
-            jar.setCookie('ipv6cookie=ipv6val; Secure', 'http://[::1]/'),
-          ).rejects.toThrow(
-            'Cookie is Secure but this is not a secure connection',
-          )
-        })
-
-        it('should throw when setting a Secure cookie on http://subdomain.localhost', async () => {
-          await expect(
-            jar.setCookie(
-              'appcookie=someval; Secure',
-              'http://subdomain.localhost/',
-            ),
-          ).rejects.toThrow(
-            'Cookie is Secure but this is not a secure connection',
-          )
-        })
-
-        it('should NOT throw if ignoreError=true, but the cookie is NOT stored', async () => {
-          await expect(
-            jar.setCookie('ignoredCookie=val; Secure', 'http://localhost/', {
-              ignoreError: true,
-            }),
-          ).resolves.toBeUndefined()
-
-          const cookies = await jar.getCookies('http://localhost/')
-          expect(cookies.map((c) => c.key)).not.toContain('ignoredCookie')
-        })
-      })
-
       describe('Storing a secure cookie on a secure local origin', () => {
         it('should allow storing on https://localhost and retrieve it from https://localhost', async () => {
           // https:// is always considered potentially trustworthy

--- a/lib/__tests__/cookiePrefixes.spec.ts
+++ b/lib/__tests__/cookiePrefixes.spec.ts
@@ -40,18 +40,6 @@ describe('When `prefixSecurity` is enabled for `CookieJar`', () => {
           }),
         ])
       })
-
-      it('should throw if cookie has Secure attribute but domain is http', async () => {
-        await expect(
-          cookieJar.setCookie(
-            '__Secure-SID=12345; Domain=example.com; Secure',
-            insecureUrl,
-            {},
-          ),
-        ).rejects.toThrow(
-          'Cookie is Secure but this is not a secure connection',
-        )
-      })
     })
 
     describe('__Host prefix', () => {

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -608,23 +608,7 @@ export class CookieJar {
       cookie.pathIsDefault = true
     }
 
-    // S5.3 step 8: secure attribute:
-    // "If the request-uri does not denote a "secure" connection
-    // (as defined by the user agent), and the cookie's secure-only-flag
-    // is true, then abort these steps and ignore the cookie entirely."
-    const potentiallyTrustworthy = isPotentiallyTrustworthy(
-      url,
-      this.allowSecureOnLocal,
-    )
-    if (!potentiallyTrustworthy && cookie.secure) {
-      const err = new Error(
-        'Cookie is Secure but this is not a secure connection',
-      )
-      return options?.ignoreError
-        ? promiseCallback.resolve(undefined)
-        : promiseCallback.reject(err)
-    }
-
+    // S5.3 step 8: NOOP; secure attribute
     // S5.3 step 9: NOOP; httpOnly attribute
 
     // S5.3 step 10


### PR DESCRIPTION
This change was introduce in https://github.com/salesforce/tough-cookie/pull/498. As this new feature was driven by current browser behaviors + updates to the terminology for "secure" connections from RFC6265bis-19, it seemed appropriate to also apply the following check from RFC6265bis-19 when setting a cookie:

> If the request-uri does not denote a "secure" connection (as defined by the user agent), and the cookie's secure-only-flag is true, then abort these steps and ignore the cookie entirely.
> - https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-19#section-5.7-3.13.1

This deviates from RFC6265 which does not describe any check for a "secure" connection when setting a cookie, only when retrieving the cookie.

In our integration tests for JSDOM, this code also causes a failure in their Web Platform Test suite around passing cookies to Websocket connections. Testing the behavior for this in various browsers showed inconsistent results which I'll summarize below:

| Browser | HTTP → WSS | HTTPS → WSS |
|---------|------------|-------------|
| Chrome  | Fail       | Pass        |
| Firefox | Pass       | Pass        |
| Safari  | Fail       | Pass        |
| Edge    | Fail       | Pass        |

As it's unclear what the correct behavior should be here, I think we should revert this check to restore the previous behavior in https://github.com/salesforce/tough-cookie/blob/v5.1.2/lib/cookie/cookieJar.ts#L595 to what RFC6265 defines.