### PR TITLE
Prepare release v6.0.0-rc.1

### DIFF
--- a/api/docs/tough-cookie.version.md
+++ b/api/docs/tough-cookie.version.md
@@ -9,5 +9,5 @@ The version of `tough-cookie`
 **Signature:**
 
 ```typescript
-version = "6.0.0-rc.0"
+version = "6.0.0-rc.1"
 ```

--- a/api/tough-cookie.api.md
+++ b/api/tough-cookie.api.md
@@ -300,7 +300,7 @@ export class Store {
 }
 
 // @public
-export const version = "6.0.0-rc.0";
+export const version = "6.0.0-rc.1";
 
 // (No @packageDocumentation comment for this package)
 

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -2,4 +2,4 @@
  * The version of `tough-cookie`
  * @public
  */
-export const version = '6.0.0-rc.0'
+export const version = '6.0.0-rc.1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tough-cookie",
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tough-cookie",
-      "version": "6.0.0-rc.0",
+      "version": "6.0.0-rc.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "RFC6265",
     "RFC2965"
   ],
-  "version": "6.0.0-rc.0",
+  "version": "6.0.0-rc.1",
   "homepage": "https://github.com/salesforce/tough-cookie",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Includes changes from https://github.com/salesforce/tough-cookie/compare/v6.0.0-rc.0...v6.0.0-rc.1