### PR TITLE
test(timing): retry flaky test and increase threshold

### DIFF
--- a/lib/__tests__/parse.spec.ts
+++ b/lib/__tests__/parse.spec.ts
@@ -440,6 +440,7 @@ describe('Cookie.parse', () => {
     },
   ])(
     'Cookie.parse("$prefix $postfix") should not take significantly longer to run than Cookie.parse("$prefix<TOO MANY SPACES>$postfix")',
+    { retry: 3 },
     ({ prefix, postfix, parseOptions = {} }) => {
       const shortVersion = `${prefix} ${postfix}`
       const startShortVersionParse = performance.now()
@@ -454,7 +455,7 @@ describe('Cookie.parse', () => {
       const ratio =
         (endLongVersionParse - startLongVersionParse) /
         (endShortVersionParse - startShortVersionParse)
-      expect(ratio).toBeLessThan(250) // if broken this ratio goes 2000-4000x higher
+      expect(ratio).toBeLessThan(300) // if broken this ratio goes 2000-4000x higher
     },
   )
 })


### PR DESCRIPTION
In #546, we upgraded vitest from v3 to v4. I'm not sure why, but this broke the test that asserts the parsing speed of short vs long strings. Now the ratio is above the threshold about 80% of the time (on my machine), being consistently in the range of 300-400.

This PR increases the threshold slightly (to 300 instead of 250) and retries the one test up to three times if it fails. The tests reliably passed (50/50 runs) with this configuration.