### PR TITLE
Review Section 5.1.3. Domain Matching

### DIFF
--- a/api/docs/tough-cookie.domainmatch.md
+++ b/api/docs/tough-cookie.domainmatch.md
@@ -86,6 +86,8 @@ boolean \| undefined
 
 ## Remarks
 
+This implementation is compliant with RFC6265 Section 5.1.3 and compatible with [draft-ietf-httpbis-rfc6265bis-22](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3) which adds a clarifying note that both inputs must be canonicalized but is otherwise identical.
+
 \#\#\# 5.1.3. Domain Matching
 
 A string domain-matches a given domain string if at least one of the following conditions hold:

--- a/lib/__tests__/domainMatch.spec.ts
+++ b/lib/__tests__/domainMatch.spec.ts
@@ -9,6 +9,9 @@ describe('domainMatch', () => {
       ['example.com', null, undefined],
       [null, null, undefined],
       [undefined, undefined, undefined],
+      ['', 'example.com', false],
+      ['example.com', '', false],
+      ['', '', true],
     ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
       expect(domainMatch(domain, cookieDomain)).toBe(expected)
     })
@@ -35,6 +38,7 @@ describe('domainMatch', () => {
     it.each([
       ['example.com', 'example.com', true],
       ['com', 'com', true],
+      ['localhost', 'localhost', true],
       ['::1', '::1', true], // identical IPv6
       ['::3Xam:1e', '::3xaM:1e', true], // identical after canonicalization, even though malformed
       ['3xam::1e', '3xam::1e', true], // identical malformed IPv6
@@ -72,6 +76,10 @@ describe('domainMatch', () => {
 
       // trailing dot
       ['example.com', 'example.com.', false], // RFC6265 S4.1.2.3
+
+      // dot-only inputs
+      ['.', '.', true],
+      ['..', '.', true], // canonicalization strips leading dot from '..' leaving '.', which matches
     ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
       expect(domainMatch(domain, cookieDomain)).toBe(expected)
     })
@@ -116,6 +124,20 @@ describe('domainMatch', () => {
       ['192.168.0.1.example.com', 'example.com', true],
     ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
       expect(domainMatch(domain, cookieDomain)).toBe(expected)
+    })
+  })
+
+  describe('canonicalize=false', () => {
+    it.each([
+      // pre-canonicalized inputs match normally
+      ['www.example.com', 'example.com', true],
+      ['example.com', 'example.com', true],
+      // mixed case is NOT canonicalized — fails identity check
+      ['Example.com', 'example.com', false],
+      // leading dot is NOT stripped
+      ['www.google.com', '.google.com', false],
+    ])('domainMatch(%s, %s, false) => %s', (domain, cookieDomain, expected) => {
+      expect(domainMatch(domain, cookieDomain, false)).toBe(expected)
     })
   })
 })

--- a/lib/__tests__/domainMatch.spec.ts
+++ b/lib/__tests__/domainMatch.spec.ts
@@ -2,82 +2,120 @@ import { describe, expect, it } from 'vitest'
 import { domainMatch } from '../cookie/domainMatch.js'
 
 describe('domainMatch', () => {
-  it.each([
-    // string,       domain,       expect
-    ['example.com', 'example.com', true], // identical
-    ['eXaMpLe.cOm', 'ExAmPlE.CoM', true], // both canonicalized
-    ['no.ca', 'yes.ca', false],
-    ['wwwexample.com', 'example.com', false],
-    ['www.subdom.example.com', 'example.com', true],
-    ['www.subdom.example.com', 'subdom.example.com', true],
-    ['example.com', 'example.com.', false], // RFC6265 S4.1.2.3
+  // Library-specific behavior (not in RFC)
+  describe('null and undefined inputs', () => {
+    it.each([
+      [null, 'example.com', undefined],
+      ['example.com', null, undefined],
+      [null, null, undefined],
+      [undefined, undefined, undefined],
+    ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
+      expect(domainMatch(domain, cookieDomain)).toBe(expected)
+    })
+  })
 
-    // nulls and undefineds
-    [null, 'example.com', undefined],
-    ['example.com', null, undefined],
-    [null, null, undefined],
-    [undefined, undefined, undefined],
+  describe('canonicalization', () => {
+    it.each([
+      // mixed case is canonicalized before comparison
+      ['eXaMpLe.cOm', 'ExAmPlE.CoM', true],
+      ['NOTATLD', 'notaTLD', true],
+      // leading dot is stripped during canonicalization
+      ['www.google.com', '.google.com', true],
+      // non-ASCII hostnames are punycode-encoded during canonicalization
+      ['\u{1FAE0}.com', 'xn--129h.com', true], // Emoji
+      ['\u03C1\u04BB\u0456\u0455\u04BB.info', 'xn--2xa01ac71bc.info', true], // Greek + Cyrillic
+      ['\u732B.cat', 'xn--z7x.cat', true], // Japanese
+    ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
+      expect(domainMatch(domain, cookieDomain)).toBe(expected)
+    })
+  })
 
-    // suffix matching:
-    ['www.example.com', 'example.com', true], // substr AND suffix
-    ['www.example.com.org', 'example.com', false], // substr but not suffix
-    ['example.com', 'www.example.com.org', false], // neither
-    ['example.com', 'www.example.com', false], // super-str
-    ['aaa.com', 'aaaa.com', false], // str can't be suffix of domain
-    ['aaaa.com', 'aaa.com', false], // dom is suffix, but has to match on "." boundary!
-    ['www.aaaa.com', 'aaa.com', false],
-    ['www.aaa.com', 'aaa.com', true],
-    ['www.aexample.com', 'example.com', false], // has to match on "." boundary
-    ['computer.com', 'com', true], // suffix string found at start of domain
-    ['becoming.com', 'com', true], // suffix string found in middle of domain
-    ['sitcom.com', 'com', true], // suffix string found just before the '.' boundary
+  // RFC 6265 Section 5.1.3 conditions
+  describe('identical strings', () => {
+    it.each([
+      ['example.com', 'example.com', true],
+      ['com', 'com', true],
+      ['::1', '::1', true], // identical IPv6
+      ['::3Xam:1e', '::3xaM:1e', true], // identical after canonicalization, even though malformed
+      ['3xam::1e', '3xam::1e', true], // identical malformed IPv6
+      ['com', 'net', false], // same length, not identical
+    ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
+      expect(domainMatch(domain, cookieDomain)).toBe(expected)
+    })
+  })
 
-    // S5.1.3 "The string is a host name (i.e., not an IP address)"
-    ['192.168.0.1', '168.0.1', false], // because str is an IP (v4)
-    ['100.192.168.0.1', '168.0.1', true], // WEIRD: because str is not a valid IPv4
-    ['100.192.168.0.1', '192.168.0.1', true], // WEIRD: because str is not a valid IPv4
-    ['::ffff:192.168.0.1', '168.0.1', false], // because str is an IP (v6)
-    ['::ffff:192.168.0.1', '192.168.0.1', false], // because str is an IP (v6)
-    ['::FFFF:192.168.0.1', '192.168.0.1', false], // because str is an IP (v6)
-    ['::192.168.0.1', '192.168.0.1', false], // because str is an IP (yes, v6!)
-    [':192.168.0.1', '168.0.1', true], // WEIRD: because str is not valid IPv6
-    [':ffff:100.192.168.0.1', '192.168.0.1', true], // WEIRD: because str is not valid IPv6
-    [':ffff:192.168.0.1', '192.168.0.1', false],
-    [':ffff:192.168.0.1', '168.0.1', true], // WEIRD: because str is not valid IPv6
-    ['::Fxxx:192.168.0.1', '168.0.1', true], // WEIRD: because str isnt IPv6
-    ['192.168.0.1', '68.0.1', false],
-    ['192.168.0.1', '2.68.0.1', false],
-    ['192.168.0.1', '92.68.0.1', false],
-    ['10.1.2.3', '210.1.2.3', false],
-    ['2008::1', '::1', false],
-    ['::1', '2008::1', false],
-    ['::1', '::1', true], // "are identical" rule, despite IPv6
-    ['::3xam:1e', '2008::3xam:1e', false], // malformed IPv6
-    ['::3Xam:1e', '::3xaM:1e', true], // identical, even though malformed
-    ['3xam::1e', '3xam::1e', true], // identical
-    ['::3xam::1e', '3xam::1e', false],
-    ['3xam::1e', '::3xam:1e', false],
-    ['::f00f:10.0.0.1', '10.0.0.1', false],
-    ['10.0.0.1', '::f00f:10.0.0.1', false],
+  describe('suffix matching with dot boundary', () => {
+    it.each([
+      // valid suffix matches
+      ['www.example.com', 'example.com', true],
+      ['www.subdom.example.com', 'example.com', true],
+      ['www.subdom.example.com', 'subdom.example.com', true],
+      ['www.aaa.com', 'aaa.com', true],
+      ['computer.com', 'com', true], // suffix string found at start of domain
+      ['becoming.com', 'com', true], // suffix string found in middle of domain
+      ['sitcom.com', 'com', true], // suffix string found just before '.' boundary
 
-    // "IP like" hostnames:
-    ['1.example.com', 'example.com', true],
-    ['11.example.com', 'example.com', true],
-    ['192.168.0.1.example.com', 'example.com', true],
+      // not a suffix
+      ['no.ca', 'yes.ca', false],
+      ['www.example.com.org', 'example.com', false], // substring but not suffix
+      ['example.com', 'www.example.com.org', false], // neither
 
-    // exact length "TLD" tests:
-    ['com', 'net', false], // same len, non-match
-    ['com', 'com', true], // "are identical" rule
-    ['NOTATLD', 'notaTLD', true], // "are identical" rule (after canonicalization)
+      // suffix but not on dot boundary
+      ['wwwexample.com', 'example.com', false],
+      ['aaaa.com', 'aaa.com', false],
+      ['www.aaaa.com', 'aaa.com', false],
+      ['www.aexample.com', 'example.com', false],
 
-    // non-ASCII hostnames
-    ['🫠.com', 'xn--129h.com', true], // Emoji!
-    ['ρһіѕһ.info', 'xn--2xa01ac71bc.info', true], // Greek + Cyrillic characters
-    ['猫.cat', 'xn--z7x.cat', true], // Japanese characters
+      // domain is super-string of string
+      ['example.com', 'www.example.com', false],
+      ['aaa.com', 'aaaa.com', false],
 
-    // domain that needs to be canonicalized
-    ['www.google.com', '.google.com', true],
-  ])('domainMatch(%s, %s) => %s', (string, domain, expectedValue) => {
-    expect(domainMatch(string, domain)).toBe(expectedValue)
+      // trailing dot
+      ['example.com', 'example.com.', false], // RFC6265 S4.1.2.3
+    ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
+      expect(domainMatch(domain, cookieDomain)).toBe(expected)
+    })
+  })
+
+  describe('IP address rejection', () => {
+    it.each([
+      // IPv4 addresses rejected for suffix matching
+      ['192.168.0.1', '168.0.1', false],
+      ['192.168.0.1', '68.0.1', false],
+      ['192.168.0.1', '2.68.0.1', false],
+      ['192.168.0.1', '92.68.0.1', false],
+      ['10.1.2.3', '210.1.2.3', false],
+
+      // IPv6 addresses rejected for suffix matching
+      ['::ffff:192.168.0.1', '168.0.1', false],
+      ['::ffff:192.168.0.1', '192.168.0.1', false],
+      ['::FFFF:192.168.0.1', '192.168.0.1', false],
+      ['::192.168.0.1', '192.168.0.1', false],
+      ['2008::1', '::1', false],
+      ['::1', '2008::1', false],
+      ['::f00f:10.0.0.1', '10.0.0.1', false],
+      ['10.0.0.1', '::f00f:10.0.0.1', false],
+      [':ffff:192.168.0.1', '192.168.0.1', false],
+
+      // malformed IPv6
+      ['::3xam:1e', '2008::3xam:1e', false],
+      ['::3xam::1e', '3xam::1e', false],
+      ['3xam::1e', '::3xam:1e', false],
+
+      // invalid IPs that pass as hostnames (suffix match succeeds)
+      ['100.192.168.0.1', '168.0.1', true], // not a valid IPv4 (5 octets)
+      ['100.192.168.0.1', '192.168.0.1', true], // not a valid IPv4 (5 octets)
+      [':192.168.0.1', '168.0.1', true], // not valid IPv6 (single colon prefix)
+      [':ffff:100.192.168.0.1', '192.168.0.1', true], // not valid IPv6
+      [':ffff:192.168.0.1', '168.0.1', true], // not valid IPv6
+      ['::Fxxx:192.168.0.1', '168.0.1', true], // not valid IPv6 (invalid hex)
+
+      // IP-like hostnames (contain dots and numbers but are valid hostnames)
+      ['1.example.com', 'example.com', true],
+      ['11.example.com', 'example.com', true],
+      ['192.168.0.1.example.com', 'example.com', true],
+    ])('domainMatch(%s, %s) => %s', (domain, cookieDomain, expected) => {
+      expect(domainMatch(domain, cookieDomain)).toBe(expected)
+    })
   })
 })

--- a/lib/cookie/domainMatch.ts
+++ b/lib/cookie/domainMatch.ts
@@ -14,6 +14,10 @@ const IP_REGEX_LOWERCASE =
  * but it helps to think of it as a "suffix match".
  *
  * @remarks
+ * This implementation is compliant with RFC6265 Section 5.1.3 and compatible with
+ * {@link https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3 | draft-ietf-httpbis-rfc6265bis-22}
+ * which adds a clarifying note that both inputs must be canonicalized but is otherwise identical.
+ *
  * ### 5.1.3.  Domain Matching
  *
  * A string domain-matches a given domain string if at least one of the
@@ -49,6 +53,7 @@ export function domainMatch(
   cookieDomain?: Nullable<string>,
   canonicalize?: boolean,
 ): boolean | undefined {
+  // Library-specific: null/undefined input handling (not in RFC)
   if (domain == null || cookieDomain == null) {
     return undefined
   }
@@ -56,6 +61,8 @@ export function domainMatch(
   let _str: Nullable<string>
   let _domStr: Nullable<string>
 
+  // Library-specific: optional canonicalization (not in RFC)
+  // The RFC algorithm assumes inputs are already canonicalized.
   if (canonicalize !== false) {
     _str = canonicalDomain(domain)
     _domStr = canonicalDomain(cookieDomain)
@@ -64,44 +71,50 @@ export function domainMatch(
     _domStr = cookieDomain
   }
 
+  // Library-specific: canonicalization failure handling (not in RFC)
   if (_str == null || _domStr == null) {
     return undefined
   }
 
-  /*
-   * S5.1.3:
-   * "A string domain-matches a given domain string if at least one of the
-   * following conditions hold:"
-   *
-   * " o The domain string and the string are identical. (Note that both the
-   * domain string and the string will have been canonicalized to lower case at
-   * this point)"
-   */
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3-1
+  // Note: This algorithm expects that both inputs are canonicalized.
+
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3-2
+  // A string domain-matches a given domain string if at least one of the
+  // following conditions hold:
+
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3-3.1.1
+  // The domain string and the string are identical. (Note that both the
+  // domain string and the string will have been canonicalized to lower case at
+  // this point.)
   if (_str == _domStr) {
     return true
   }
 
-  /* " o All of the following [three] conditions hold:" */
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3-3.2.1
+  // All of the following conditions hold:
 
-  /* "* The domain string is a suffix of the string" */
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3-3.2.2.1.1
+  // The domain string is a suffix of the string.
   const idx = _str.lastIndexOf(_domStr)
   if (idx <= 0) {
     return false // it's a non-match (-1) or prefix (0)
   }
 
-  // next, check it's a proper suffix
-  // e.g., "a.b.c".indexOf("b.c") === 2
-  // 5 === 3+2
+  // Verify it's a proper suffix (not just a substring match)
+  // e.g., "a.b.c".lastIndexOf("b.c") === 2, and 5 === 3 + 2
   if (_str.length !== _domStr.length + idx) {
     return false // it's not a suffix
   }
 
-  /* "  * The last character of the string that is not included in the
-   * domain string is a %x2E (".") character." */
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3-3.2.2.2.1
+  // The last character of the string that is not included in the
+  // domain string is a %x2E (".") character.
   if (_str.substring(idx - 1, idx) !== '.') {
     return false // doesn't align on "."
   }
 
-  /* "  * The string is a host name (i.e., not an IP address)." */
+  // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3-3.2.2.3.1
+  // The string is a host name (i.e., not an IP address).
   return !IP_REGEX_LOWERCASE.test(_str)
 }


### PR DESCRIPTION
## Summary

- Restructure `domainMatch.spec.ts` from a flat `it.each` into 5 grouped `describe` blocks matching RFC conditions (identical strings, suffix matching, IP address rejection) and library-specific behavior (null/undefined, canonicalization)
- Add 10 new edge case tests: empty strings, single-label domains (`localhost`), dot-only domains, and `canonicalize=false` parameter path
- Annotate `domainMatch.ts` with fine-grained [draft-ietf-httpbis-rfc6265bis-22](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-22#section-5.1.3) section anchors and mark library-specific behavior (null handling, optional canonicalization) as not in RFC
- Add bis-22 compatibility note to JSDoc `@remarks`
- Regenerate API documentation

No behavioral or API changes.

## Test Plan

- [x] All 782 tests pass (`vitest run`)
- [x] Linting clean (`npm run lint`)
- [x] API docs regenerated

Closes #513