### PR TITLE
feat: introduce CookiePath nominal type

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default config(
       ...vitest.configs.recommended.rules,
       // We only run tests in node, so we can use node's builtins
       'import/no-nodejs-modules': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default config(
       ...vitest.configs.recommended.rules,
       // We only run tests in node, so we can use node's builtins
       'import-x/no-nodejs-modules': 'off',
+      '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
   {

--- a/lib/__tests__/cookiePath.spec.ts
+++ b/lib/__tests__/cookiePath.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { CookiePath } from '../cookie/cookiePath.js'
+
+describe('CookiePath', () => {
+  describe('ROOT', () => {
+    it('equals "/"', () => {
+      expect(CookiePath.ROOT).toBe('/')
+    })
+  })
+
+  describe('parse', () => {
+    it.each([
+      { input: '/', expected: '/' },
+      { input: '/foo', expected: '/foo' },
+      { input: '/foo/bar', expected: '/foo/bar' },
+      { input: '/foo/bar/', expected: '/foo/bar/' },
+    ])('returns CookiePath for valid input "$input"', ({ input, expected }) => {
+      expect(CookiePath.parse(input)).toBe(expected)
+    })
+
+    it.each([
+      { input: '', description: 'empty string' },
+      { input: 'foo', description: 'no leading slash' },
+      { input: 'bar/baz', description: 'relative path' },
+    ])('returns undefined for $description', ({ input }) => {
+      expect(CookiePath.parse(input)).toBeUndefined()
+    })
+  })
+})

--- a/lib/__tests__/cookiePath.spec.ts
+++ b/lib/__tests__/cookiePath.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { CookiePath } from '../cookie/cookiePath.js'
 import { defaultPathCases } from './data/defaultPathCases.js'
 import { pathMatchCases } from './data/pathMatchCases.js'
+import { permutePathCases } from './data/permutePathCases.js'
 
 describe('CookiePath', () => {
   describe('ROOT', () => {
@@ -35,12 +36,9 @@ describe('CookiePath', () => {
       { input: '/foo/bar', expected: '/foo' },
       { input: '/foo/bar/', expected: '/foo/bar' },
       { input: '/foo', expected: '/' },
-    ])(
-      'parentPath of "$input" is "$expected"',
-      ({ input, expected }) => {
-        expect(CookiePath.parentPath(CookiePath.parse(input)!)).toBe(expected)
-      },
-    )
+    ])('parentPath of "$input" is "$expected"', ({ input, expected }) => {
+      expect(CookiePath.parentPath(CookiePath.parse(input)!)).toBe(expected)
+    })
 
     it('returns undefined for ROOT', () => {
       expect(CookiePath.parentPath(CookiePath.ROOT)).toBeUndefined()
@@ -66,6 +64,21 @@ describe('CookiePath', () => {
             CookiePath.parse(cookiePath)!,
           ),
         ).toBe(expectedValue)
+      },
+    )
+  })
+
+  describe('permute', () => {
+    it.each([...permutePathCases])(
+      'permute("$path") => $permutations',
+      ({ path, permutations }) => {
+        const parsed = CookiePath.parse(path)!
+        expect(CookiePath.permute(parsed)).toEqual([...permutations])
+        permutations.forEach((permutation) => {
+          expect(CookiePath.match(parsed, CookiePath.parse(permutation)!)).toBe(
+            true,
+          )
+        })
       },
     )
   })

--- a/lib/__tests__/cookiePath.spec.ts
+++ b/lib/__tests__/cookiePath.spec.ts
@@ -26,4 +26,22 @@ describe('CookiePath', () => {
       expect(CookiePath.parse(input)).toBeUndefined()
     })
   })
+
+  describe('parentPath', () => {
+    it.each([
+      { input: '/foo/bar/baz', expected: '/foo/bar' },
+      { input: '/foo/bar', expected: '/foo' },
+      { input: '/foo/bar/', expected: '/foo/bar' },
+      { input: '/foo', expected: '/' },
+    ])(
+      'parentPath of "$input" is "$expected"',
+      ({ input, expected }) => {
+        expect(CookiePath.parentPath(CookiePath.parse(input)!)).toBe(expected)
+      },
+    )
+
+    it('returns undefined for ROOT', () => {
+      expect(CookiePath.parentPath(CookiePath.ROOT)).toBeUndefined()
+    })
+  })
 })

--- a/lib/__tests__/cookiePath.spec.ts
+++ b/lib/__tests__/cookiePath.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { CookiePath } from '../cookie/cookiePath.js'
+import { defaultPathCases } from './data/defaultPathCases.js'
 
 describe('CookiePath', () => {
   describe('ROOT', () => {
@@ -43,5 +44,14 @@ describe('CookiePath', () => {
     it('returns undefined for ROOT', () => {
       expect(CookiePath.parentPath(CookiePath.ROOT)).toBeUndefined()
     })
+  })
+
+  describe('defaultPath', () => {
+    it.each([...defaultPathCases])(
+      'defaultPath($input) => "$expected"',
+      ({ input, expected }) => {
+        expect(CookiePath.defaultPath(input)).toBe(expected)
+      },
+    )
   })
 })

--- a/lib/__tests__/cookiePath.spec.ts
+++ b/lib/__tests__/cookiePath.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { CookiePath } from '../cookie/cookiePath.js'
 import { defaultPathCases } from './data/defaultPathCases.js'
+import { pathMatchCases } from './data/pathMatchCases.js'
 
 describe('CookiePath', () => {
   describe('ROOT', () => {
@@ -51,6 +52,20 @@ describe('CookiePath', () => {
       'defaultPath($input) => "$expected"',
       ({ input, expected }) => {
         expect(CookiePath.defaultPath(input)).toBe(expected)
+      },
+    )
+  })
+
+  describe('match', () => {
+    it.each(pathMatchCases)(
+      'match("%s", "%s") => %s',
+      (requestPath, cookiePath, expectedValue) => {
+        expect(
+          CookiePath.match(
+            CookiePath.parse(requestPath)!,
+            CookiePath.parse(cookiePath)!,
+          ),
+        ).toBe(expectedValue)
       },
     )
   })

--- a/lib/__tests__/cookiePath.spec.ts
+++ b/lib/__tests__/cookiePath.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { CookiePath } from '../cookie/cookiePath.js'
+import * as CookiePath from '../cookie/cookiePath.js'
 import { defaultPathCases } from './data/defaultPathCases.js'
 import { pathMatchCases } from './data/pathMatchCases.js'
 import { permutePathCases } from './data/permutePathCases.js'
@@ -46,7 +46,7 @@ describe('CookiePath', () => {
   })
 
   describe('defaultPath', () => {
-    it.each([...defaultPathCases])(
+    it.each(defaultPathCases)(
       'defaultPath($input) => "$expected"',
       ({ input, expected }) => {
         expect(CookiePath.defaultPath(input)).toBe(expected)
@@ -69,7 +69,7 @@ describe('CookiePath', () => {
   })
 
   describe('permute', () => {
-    it.each([...permutePathCases])(
+    it.each(permutePathCases)(
       'permute("$path") => $permutations',
       ({ path, permutations }) => {
         const parsed = CookiePath.parse(path)!

--- a/lib/__tests__/data/defaultPathCases.ts
+++ b/lib/__tests__/data/defaultPathCases.ts
@@ -1,0 +1,7 @@
+export const defaultPathCases = [
+  { input: null, expected: '/' },
+  { input: '/', expected: '/' },
+  { input: '/file', expected: '/' },
+  { input: '/dir/file', expected: '/dir' },
+  { input: 'noslash', expected: '/' },
+] as const

--- a/lib/__tests__/data/defaultPathCases.ts
+++ b/lib/__tests__/data/defaultPathCases.ts
@@ -1,3 +1,5 @@
+// Shared between the CookiePath.defaultPath spec and the deprecated
+// `defaultPath` wrapper spec so both are verified against the same corpus.
 export const defaultPathCases = [
   { input: null, expected: '/' },
   { input: '/', expected: '/' },

--- a/lib/__tests__/data/pathMatchCases.ts
+++ b/lib/__tests__/data/pathMatchCases.ts
@@ -1,0 +1,10 @@
+export const pathMatchCases: [string, string, boolean][] = [
+  // [requestPath, cookiePath, expectedMatch]
+  ['/', '/', true],
+  ['/dir', '/', true],
+  ['/', '/dir', false],
+  ['/dir/', '/dir/', true],
+  ['/dir/file', '/dir/', true],
+  ['/dir/file', '/dir', true],
+  ['/directory', '/dir', false],
+]

--- a/lib/__tests__/data/pathMatchCases.ts
+++ b/lib/__tests__/data/pathMatchCases.ts
@@ -1,6 +1,9 @@
+// Shared between the CookiePath.match spec and the deprecated `pathMatch`
+// wrapper spec so both are verified against the same corpus.
 export const pathMatchCases: [string, string, boolean][] = [
   // [requestPath, cookiePath, expectedMatch]
   ['/', '/', true],
+  ['/dir', '/dir', true],
   ['/dir', '/', true],
   ['/', '/dir', false],
   ['/dir/', '/dir/', true],

--- a/lib/__tests__/data/permutePathCases.ts
+++ b/lib/__tests__/data/permutePathCases.ts
@@ -1,0 +1,18 @@
+export const permutePathCases = [
+  {
+    path: '/',
+    permutations: ['/'],
+  },
+  {
+    path: '/foo',
+    permutations: ['/foo', '/'],
+  },
+  {
+    path: '/foo/bar',
+    permutations: ['/foo/bar', '/foo', '/'],
+  },
+  {
+    path: '/foo/bar/',
+    permutations: ['/foo/bar/', '/foo/bar', '/foo', '/'],
+  },
+] as const

--- a/lib/__tests__/data/permutePathCases.ts
+++ b/lib/__tests__/data/permutePathCases.ts
@@ -1,3 +1,5 @@
+// Shared between the CookiePath.permute spec and the deprecated
+// `permutePath` wrapper spec so both are verified against the same corpus.
 export const permutePathCases = [
   {
     path: '/',

--- a/lib/cookie/cookiePath.ts
+++ b/lib/cookie/cookiePath.ts
@@ -56,4 +56,30 @@ export namespace CookiePath {
     const requestPath = parse(path ?? '') ?? ROOT
     return parentPath(requestPath) ?? ROOT
   }
+
+  /**
+   * Determines if a request path matches a cookie path per
+   * {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4 | RFC 6265 §5.1.4}.
+   *
+   * @param reqPath - the path of the request
+   * @param cookiePath - the path of the cookie
+   */
+  export function match(reqPath: CookiePath, cookiePath: CookiePath): boolean {
+    if (cookiePath === reqPath) {
+      return true
+    }
+
+    const idx = reqPath.indexOf(cookiePath)
+    if (idx === 0) {
+      if (cookiePath[cookiePath.length - 1] === '/') {
+        return true
+      }
+
+      if (reqPath.startsWith(cookiePath) && reqPath[cookiePath.length] === '/') {
+        return true
+      }
+    }
+
+    return false
+  }
 }

--- a/lib/cookie/cookiePath.ts
+++ b/lib/cookie/cookiePath.ts
@@ -1,3 +1,5 @@
+import type { Nullable } from '../utils.js'
+
 declare const tag: unique symbol
 
 /**
@@ -42,5 +44,16 @@ export namespace CookiePath {
     const lastSlashIndex = path.lastIndexOf('/')
     if (lastSlashIndex === 0) return ROOT
     return path.slice(0, lastSlashIndex) as CookiePath
+  }
+
+  /**
+   * Computes the default cookie path from a request URI path per
+   * {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4 | RFC 6265 §5.1.4}.
+   *
+   * @param path - the path portion of the request URI
+   */
+  export function defaultPath(path?: Nullable<string>): CookiePath {
+    const requestPath = parse(path ?? '') ?? ROOT
+    return parentPath(requestPath) ?? ROOT
   }
 }

--- a/lib/cookie/cookiePath.ts
+++ b/lib/cookie/cookiePath.ts
@@ -30,4 +30,17 @@ export namespace CookiePath {
     if (!input.startsWith('/')) return undefined
     return input as CookiePath
   }
+
+  /**
+   * Returns the parent path by stripping the last segment, or `undefined`
+   * if the path is already the root (`/`).
+   *
+   * @param path - a validated cookie path
+   */
+  export function parentPath(path: CookiePath): CookiePath | undefined {
+    if (path === '/') return undefined
+    const lastSlashIndex = path.lastIndexOf('/')
+    if (lastSlashIndex === 0) return ROOT
+    return path.slice(0, lastSlashIndex) as CookiePath
+  }
 }

--- a/lib/cookie/cookiePath.ts
+++ b/lib/cookie/cookiePath.ts
@@ -16,11 +16,11 @@ export type CookiePath = string & { readonly [tag]: true }
 /**
  * @public
  */
-export namespace CookiePath {
+export const CookiePath = {
   /**
    * The root cookie path (`/`).
    */
-  export const ROOT = '/' as CookiePath
+  ROOT: '/' as CookiePath,
 
   /**
    * Validates that the input starts with `/` and returns a {@link CookiePath},
@@ -28,10 +28,10 @@ export namespace CookiePath {
    *
    * @param input - the string to validate
    */
-  export function parse(input: string): CookiePath | undefined {
+  parse(input: string): CookiePath | undefined {
     if (!input.startsWith('/')) return undefined
     return input as CookiePath
-  }
+  },
 
   /**
    * Returns the parent path by stripping the last segment, or `undefined`
@@ -39,12 +39,12 @@ export namespace CookiePath {
    *
    * @param path - a validated cookie path
    */
-  export function parentPath(path: CookiePath): CookiePath | undefined {
+  parentPath(path: CookiePath): CookiePath | undefined {
     if (path === '/') return undefined
     const lastSlashIndex = path.lastIndexOf('/')
-    if (lastSlashIndex === 0) return ROOT
+    if (lastSlashIndex === 0) return CookiePath.ROOT
     return path.slice(0, lastSlashIndex) as CookiePath
-  }
+  },
 
   /**
    * Computes the default cookie path from a request URI path per
@@ -52,10 +52,10 @@ export namespace CookiePath {
    *
    * @param path - the path portion of the request URI
    */
-  export function defaultPath(path?: Nullable<string>): CookiePath {
-    const requestPath = parse(path ?? '') ?? ROOT
-    return parentPath(requestPath) ?? ROOT
-  }
+  defaultPath(path?: Nullable<string>): CookiePath {
+    const requestPath = CookiePath.parse(path ?? '') ?? CookiePath.ROOT
+    return CookiePath.parentPath(requestPath) ?? CookiePath.ROOT
+  },
 
   /**
    * Determines if a request path matches a cookie path per
@@ -64,7 +64,7 @@ export namespace CookiePath {
    * @param reqPath - the path of the request
    * @param cookiePath - the path of the cookie
    */
-  export function match(reqPath: CookiePath, cookiePath: CookiePath): boolean {
+  match(reqPath: CookiePath, cookiePath: CookiePath): boolean {
     if (cookiePath === reqPath) {
       return true
     }
@@ -75,11 +75,38 @@ export namespace CookiePath {
         return true
       }
 
-      if (reqPath.startsWith(cookiePath) && reqPath[cookiePath.length] === '/') {
+      if (
+        reqPath.startsWith(cookiePath) &&
+        reqPath[cookiePath.length] === '/'
+      ) {
         return true
       }
     }
 
     return false
-  }
+  },
+
+  /**
+   * Generates all possible path values that {@link CookiePath.match | match} the given path.
+   * The array is in longest-to-shortest order.
+   *
+   * @param path - a validated cookie path
+   */
+  permute(path: CookiePath): CookiePath[] {
+    if (path === '/') {
+      return [CookiePath.ROOT]
+    }
+    const permutations: CookiePath[] = [path]
+    let current: string = path
+    while (current.length > 1) {
+      const lindex = current.lastIndexOf('/')
+      if (lindex === 0) {
+        break
+      }
+      current = current.slice(0, lindex)
+      permutations.push(current as CookiePath)
+    }
+    permutations.push(CookiePath.ROOT)
+    return permutations
+  },
 }

--- a/lib/cookie/cookiePath.ts
+++ b/lib/cookie/cookiePath.ts
@@ -1,0 +1,33 @@
+declare const tag: unique symbol
+
+/**
+ * A nominal type representing a validated cookie path that starts with `/`.
+ *
+ * Construct via {@link CookiePath.parse} or {@link CookiePath.ROOT}.
+ * Use {@link CookiePath.match} for RFC 6265 §5.1.4 path matching
+ * and {@link CookiePath.defaultPath} for RFC 6265 §5.1.4 default path computation.
+ *
+ * @public
+ */
+export type CookiePath = string & { readonly [tag]: true }
+
+/**
+ * @public
+ */
+export namespace CookiePath {
+  /**
+   * The root cookie path (`/`).
+   */
+  export const ROOT = '/' as CookiePath
+
+  /**
+   * Validates that the input starts with `/` and returns a {@link CookiePath},
+   * or `undefined` if the input is not a valid cookie path.
+   *
+   * @param input - the string to validate
+   */
+  export function parse(input: string): CookiePath | undefined {
+    if (!input.startsWith('/')) return undefined
+    return input as CookiePath
+  }
+}

--- a/lib/cookie/cookiePath.ts
+++ b/lib/cookie/cookiePath.ts
@@ -5,108 +5,101 @@ declare const tag: unique symbol
 /**
  * A nominal type representing a validated cookie path that starts with `/`.
  *
- * Construct via {@link CookiePath.parse} or {@link CookiePath.ROOT}.
- * Use {@link CookiePath.match} for RFC 6265 §5.1.4 path matching
- * and {@link CookiePath.defaultPath} for RFC 6265 §5.1.4 default path computation.
+ * Construct via {@link parse} or {@link ROOT}.
+ * Use {@link match} for RFC 6265 §5.1.4 path matching
+ * and {@link defaultPath} for RFC 6265 §5.1.4 default path computation.
  *
- * @public
+ * @internal
  */
 export type CookiePath = string & { readonly [tag]: true }
 
 /**
- * @public
+ * The root cookie path (`/`).
+ *
+ * @internal
  */
-export const CookiePath = {
-  /**
-   * The root cookie path (`/`).
-   */
-  ROOT: '/' as CookiePath,
+export const ROOT = '/' as CookiePath
 
-  /**
-   * Validates that the input starts with `/` and returns a {@link CookiePath},
-   * or `undefined` if the input is not a valid cookie path.
-   *
-   * @param input - the string to validate
-   */
-  parse(input: string): CookiePath | undefined {
-    if (!input.startsWith('/')) return undefined
-    return input as CookiePath
-  },
+/**
+ * Validates that the input starts with `/` and returns a {@link CookiePath},
+ * or `undefined` if the input is not a valid cookie path.
+ *
+ * @param input - the string to validate
+ * @internal
+ */
+export function parse(input: string): CookiePath | undefined {
+  return input.startsWith('/') ? (input as CookiePath) : undefined
+}
 
-  /**
-   * Returns the parent path by stripping the last segment, or `undefined`
-   * if the path is already the root (`/`).
-   *
-   * @param path - a validated cookie path
-   */
-  parentPath(path: CookiePath): CookiePath | undefined {
-    if (path === '/') return undefined
-    const lastSlashIndex = path.lastIndexOf('/')
-    if (lastSlashIndex === 0) return CookiePath.ROOT
-    return path.slice(0, lastSlashIndex) as CookiePath
-  },
+/**
+ * Returns the parent path by stripping the last segment, or `undefined`
+ * if the path is already the root (`/`).
+ *
+ * @param path - a validated cookie path
+ * @internal
+ */
+export function parentPath(path: CookiePath): CookiePath | undefined {
+  if (path === '/') return undefined
+  const lastSlashIndex = path.lastIndexOf('/')
+  if (lastSlashIndex === 0) return ROOT
+  return path.slice(0, lastSlashIndex) as CookiePath
+}
 
-  /**
-   * Computes the default cookie path from a request URI path per
-   * {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4 | RFC 6265 §5.1.4}.
-   *
-   * @param path - the path portion of the request URI
-   */
-  defaultPath(path?: Nullable<string>): CookiePath {
-    const requestPath = CookiePath.parse(path ?? '') ?? CookiePath.ROOT
-    return CookiePath.parentPath(requestPath) ?? CookiePath.ROOT
-  },
+/**
+ * Computes the default cookie path from a request URI path per
+ * {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4 | RFC 6265 §5.1.4}.
+ *
+ * @param path - the path portion of the request URI
+ * @internal
+ */
+export function defaultPath(path?: Nullable<string>): CookiePath {
+  const requestPath = parse(path ?? '') ?? ROOT
+  return parentPath(requestPath) ?? ROOT
+}
 
-  /**
-   * Determines if a request path matches a cookie path per
-   * {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4 | RFC 6265 §5.1.4}.
-   *
-   * @param reqPath - the path of the request
-   * @param cookiePath - the path of the cookie
-   */
-  match(reqPath: CookiePath, cookiePath: CookiePath): boolean {
-    if (cookiePath === reqPath) {
-      return true
+/**
+ * Determines if a request path matches a cookie path per
+ * {@link https://www.rfc-editor.org/rfc/rfc6265.html#section-5.1.4 | RFC 6265 §5.1.4}.
+ *
+ * @param reqPath - the path of the request
+ * @param cookiePath - the path of the cookie
+ * @internal
+ */
+export function match(reqPath: CookiePath, cookiePath: CookiePath): boolean {
+  // "The cookie-path and the request-path are identical."
+  if (reqPath === cookiePath) return true
+  // The remaining conditions require the cookie-path to be a prefix.
+  if (!reqPath.startsWith(cookiePath)) return false
+  // "...and the last character of the cookie-path is %x2F ("/")", or "...and
+  // the first character of the request-path not included in the cookie-path is
+  // a %x2F ("/") character."
+  return (
+    cookiePath[cookiePath.length - 1] === '/' ||
+    reqPath[cookiePath.length] === '/'
+  )
+}
+
+/**
+ * Generates all possible path values that {@link match} the given path.
+ * The array is in longest-to-shortest order.
+ *
+ * @param path - a validated cookie path
+ * @internal
+ */
+export function permute(path: CookiePath): CookiePath[] {
+  if (path === '/') {
+    return [ROOT]
+  }
+  const permutations = [path]
+  let current = path
+  while (current.length > 1) {
+    const lindex = current.lastIndexOf('/')
+    if (lindex === 0) {
+      break
     }
-
-    const idx = reqPath.indexOf(cookiePath)
-    if (idx === 0) {
-      if (cookiePath[cookiePath.length - 1] === '/') {
-        return true
-      }
-
-      if (
-        reqPath.startsWith(cookiePath) &&
-        reqPath[cookiePath.length] === '/'
-      ) {
-        return true
-      }
-    }
-
-    return false
-  },
-
-  /**
-   * Generates all possible path values that {@link CookiePath.match | match} the given path.
-   * The array is in longest-to-shortest order.
-   *
-   * @param path - a validated cookie path
-   */
-  permute(path: CookiePath): CookiePath[] {
-    if (path === '/') {
-      return [CookiePath.ROOT]
-    }
-    const permutations: CookiePath[] = [path]
-    let current: string = path
-    while (current.length > 1) {
-      const lindex = current.lastIndexOf('/')
-      if (lindex === 0) {
-        break
-      }
-      current = current.slice(0, lindex)
-      permutations.push(current as CookiePath)
-    }
-    permutations.push(CookiePath.ROOT)
-    return permutations
-  },
+    current = current.slice(0, lindex) as CookiePath
+    permutations.push(current)
+  }
+  permutations.push(ROOT)
+  return permutations
 }


### PR DESCRIPTION
## Summary

- Adds a `CookiePath` branded type and const object with `ROOT`, `parse`, `parentPath`, `defaultPath`, `match`, and `permute`
- Enforces the RFC 6265 §5.1.4 `/`-prefix invariant at compile time via a nominal type pattern
- Purely additive — no changes to existing code

Part 1 of 3 for #582. Stacked on `master`.

Next: #cookie-path-deprecate-wrappers (deprecates existing wrapper functions)