### PR TITLE
refactor: use CookiePath internally, export from public API

### DIFF
--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -3,7 +3,7 @@ import * as validators from '../validators.js'
 import { ParameterError } from '../validators.js'
 import { Store } from '../store.js'
 import { MemoryCookieStore } from '../memstore.js'
-import { pathMatch } from '../pathMatch.js'
+import { CookiePath } from './cookiePath.js'
 import { Cookie } from './cookie.js'
 import {
   Callback,
@@ -19,7 +19,6 @@ import {
   PrefixSecurityEnum,
   SerializedCookieJar,
 } from './constants.js'
-import { defaultPath } from './defaultPath.js'
 import { domainMatch } from './domainMatch.js'
 import { cookieCompare } from './cookieCompare.js'
 import { version } from '../version.js'
@@ -604,7 +603,7 @@ export class CookieJar {
     //attribute-value is not %x2F ("/"):
     //Let cookie-path be the default-path.
     if (!cookie.path || cookie.path[0] !== '/') {
-      cookie.path = defaultPath(context.pathname)
+      cookie.path = CookiePath.defaultPath(context.pathname)
       cookie.pathIsDefault = true
     }
 
@@ -872,7 +871,7 @@ export class CookieJar {
     }
 
     const host = canonicalDomain(context.hostname)
-    const path = context.pathname || '/'
+    const path = CookiePath.parse(context.pathname) ?? CookiePath.ROOT
 
     // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-19#section-5.8.3-2.1.2.3.2
     // deliberately expects the user agent to determine the notion of a "secure" connection,
@@ -920,7 +919,12 @@ export class CookieJar {
       }
 
       // "The request-uri's path path-matches the cookie's path."
-      if (!allPaths && typeof c.path === 'string' && !pathMatch(path, c.path)) {
+      const parsedCookiePath =
+        typeof c.path === 'string' ? CookiePath.parse(c.path) : undefined
+      if (
+        !allPaths &&
+        (!parsedCookiePath || !CookiePath.match(path, parsedCookiePath))
+      ) {
         return false
       }
 

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -3,7 +3,7 @@ import * as validators from '../validators.js'
 import { ParameterError } from '../validators.js'
 import { Store } from '../store.js'
 import { MemoryCookieStore } from '../memstore.js'
-import { pathMatch } from '../pathMatch.js'
+import * as CookiePath from './cookiePath.js'
 import { Cookie } from './cookie.js'
 import {
   Callback,
@@ -19,7 +19,6 @@ import {
   PrefixSecurityEnum,
   SerializedCookieJar,
 } from './constants.js'
-import { defaultPath } from './defaultPath.js'
 import { domainMatch } from './domainMatch.js'
 import { cookieCompare } from './cookieCompare.js'
 import { version } from '../version.js'
@@ -613,8 +612,7 @@ export class CookieJar {
     //attribute-value is not %x2F ("/"):
     //Let cookie-path be the default-path.
     if (!cookie.path || cookie.path[0] !== '/') {
-      // eslint-disable-next-line @typescript-eslint/no-deprecated -- migrated to CookiePath in a follow-up
-      cookie.path = defaultPath(context.pathname)
+      cookie.path = CookiePath.defaultPath(context.pathname)
       cookie.pathIsDefault = true
     }
 
@@ -882,7 +880,7 @@ export class CookieJar {
     }
 
     const host = canonicalDomain(context.hostname)
-    const path = context.pathname || '/'
+    const path = CookiePath.parse(context.pathname) ?? CookiePath.ROOT
 
     // https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-19#section-5.8.3-2.1.2.3.2
     // deliberately expects the user agent to determine the notion of a "secure" connection,
@@ -930,11 +928,11 @@ export class CookieJar {
       }
 
       // "The request-uri's path path-matches the cookie's path."
+      const parsedCookiePath =
+        typeof c.path === 'string' ? CookiePath.parse(c.path) : undefined
       if (
         !allPaths &&
-        typeof c.path === 'string' &&
-        // eslint-disable-next-line @typescript-eslint/no-deprecated -- migrated to CookiePath in a follow-up
-        !pathMatch(path, c.path)
+        (!parsedCookiePath || !CookiePath.match(path, parsedCookiePath))
       ) {
         return false
       }

--- a/lib/cookie/index.ts
+++ b/lib/cookie/index.ts
@@ -1,4 +1,5 @@
 export { MemoryCookieStore, type MemoryCookieStoreIndex } from '../memstore.js'
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { pathMatch } from '../pathMatch.js'
 export { permuteDomain } from '../permuteDomain.js'
 export {
@@ -27,10 +28,13 @@ export {
   type GetCookiesOptions,
   type SetCookieOptions,
 } from './cookieJar.js'
+export { CookiePath } from './cookiePath.js'
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { defaultPath } from './defaultPath.js'
 export { domainMatch } from './domainMatch.js'
 export { formatDate } from './formatDate.js'
 export { parseDate } from './parseDate.js'
+// eslint-disable-next-line @typescript-eslint/no-deprecated
 export { permutePath } from './permutePath.js'
 
 import { Cookie, ParseCookieOptions } from './cookie.js'

--- a/lib/memstore.ts
+++ b/lib/memstore.ts
@@ -1,5 +1,5 @@
 import type { Cookie } from './cookie/cookie.js'
-import { pathMatch } from './pathMatch.js'
+import { CookiePath } from './cookie/cookiePath.js'
 import { permuteDomain } from './permuteDomain.js'
 import { Store } from './store.js'
 import {
@@ -180,11 +180,14 @@ export class MemoryCookieStore extends Store {
         }
       }
     } else {
+      const parsedPath = CookiePath.parse(path) ?? CookiePath.ROOT
       pathMatcher = function matchRFC(domainIndex): void {
-        //NOTE: we should use path-match algorithm from S5.1.4 here
-        //(see : https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/canonical_cookie.cc#L299)
         for (const cookiePath in domainIndex) {
-          if (pathMatch(path, cookiePath)) {
+          const parsedCookiePath = CookiePath.parse(cookiePath)
+          if (
+            parsedCookiePath &&
+            CookiePath.match(parsedPath, parsedCookiePath)
+          ) {
             const pathIndex = domainIndex[cookiePath]
             for (const key in pathIndex) {
               const value = pathIndex[key]

--- a/lib/memstore.ts
+++ b/lib/memstore.ts
@@ -1,5 +1,5 @@
 import type { Cookie } from './cookie/cookie.js'
-import { pathMatch } from './pathMatch.js'
+import * as CookiePath from './cookie/cookiePath.js'
 import { permuteDomain } from './permuteDomain.js'
 import { Store } from './store.js'
 import {
@@ -180,12 +180,14 @@ export class MemoryCookieStore extends Store {
         }
       }
     } else {
+      const parsedPath = CookiePath.parse(path) ?? CookiePath.ROOT
       pathMatcher = function matchRFC(domainIndex): void {
-        //NOTE: we should use path-match algorithm from S5.1.4 here
-        //(see : https://github.com/ChromiumWebApps/chromium/blob/b3d3b4da8bb94c1b2e061600df106d590fda3620/net/cookies/canonical_cookie.cc#L299)
         for (const cookiePath in domainIndex) {
-          // eslint-disable-next-line @typescript-eslint/no-deprecated -- migrated to CookiePath in a follow-up
-          if (pathMatch(path, cookiePath)) {
+          const parsedCookiePath = CookiePath.parse(cookiePath)
+          if (
+            parsedCookiePath &&
+            CookiePath.match(parsedPath, parsedCookiePath)
+          ) {
             const pathIndex = domainIndex[cookiePath]
             for (const key in pathIndex) {
               const value = pathIndex[key]


### PR DESCRIPTION
## Summary

- Updates `cookieJar.ts` (`setCookie`, `getCookies`) to parse at boundaries and use `CookiePath` internally
- Updates `memstore.ts` (`findCookies`) to parse at boundaries and use `CookiePath` internally
- Exports `CookiePath` type and const object from the public API
- Removes stale TODO comment in memstore that noted the need for proper §5.1.4 path matching (now addressed by `CookiePath.match`)

Part 3 of 3 for #582. Stacked on `cookie-path-deprecate-wrappers` (#599).

Closes #582