### PR TITLE
fix: require explicit Path attribute for __Host- prefixed cookies

### DIFF
--- a/lib/__tests__/cookiePrefixes.spec.ts
+++ b/lib/__tests__/cookiePrefixes.spec.ts
@@ -158,6 +158,29 @@ describe('When `prefixSecurity` is enabled for `CookieJar`', () => {
           `Cookie has __Host prefix but either Secure or HostOnly attribute is not set or Path is not '/'`,
         )
       })
+
+      it('should error when there is no explicit Path attribute', async () => {
+        await expect(
+          cookieJar.setCookie('__Host-SID=12345; Secure', secureUrl, {}),
+        ).rejects.toThrow(
+          `Cookie has __Host prefix but either Secure or HostOnly attribute is not set or Path is not '/'`,
+        )
+      })
+
+      it('should work with an explicit Path of /', async () => {
+        await cookieJar.setCookie(
+          '__Host-SID=12345; Secure; Path=/',
+          secureUrl,
+          {},
+        )
+        const cookies = await cookieJar.getCookies(secureUrl)
+        expect(cookies).toEqual([
+          expect.objectContaining({
+            key: '__Host-SID',
+            value: '12345',
+          }),
+        ])
+      })
     })
   })
 

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -278,7 +278,8 @@ function isHostPrefixConditionMet(cookie: Cookie): boolean {
       cookie.secure &&
       cookie.hostOnly &&
       cookie.path != null &&
-      cookie.path === '/',
+      cookie.path === '/' &&
+      !cookie.pathIsDefault,
     )
   )
 }


### PR DESCRIPTION
## Summary

A `__Host-` prefixed cookie is accepted even when it carries no explicit `Path` attribute, as long as the request path defaults to `/`.

RFC 6265bis-19 [section 5.7, step 21, criterion 3](https://www.ietf.org/archive/id/draft-ietf-httpbis-rfc6265bis-19.html#section-5.7) reads:

> The cookie-attribute-list contains an attribute with an attribute-name of "Path", and the cookie's path is "/".

So an explicit `Path` attribute must be present; it is not enough for the effective path to equal `/`.

`isHostPrefixConditionMet` only checked the effective path. By the time it runs, the default-path algorithm has already set `cookie.path = '/'` for an attribute-less cookie, so the check passes when it should not.

## Repro (on the current `master`)

```js
const jar = new CookieJar(null, { prefixSecurity: 'strict' })

// no explicit Path attribute -> should be rejected, currently accepted
await jar.setCookie('__Host-x=1; Secure', 'https://example.com/')
// stored as "__Host-x=1; Path=/; Secure", cookie.pathIsDefault === true

// explicit Path=/ -> correctly accepted
await jar.setCookie('__Host-y=1; Secure; Path=/', 'https://example.com/')
// cookie.pathIsDefault === null
```

## Fix

`pathIsDefault` already distinguishes the two cases: `true` when the path was filled by the default-path algorithm (no `Path` attribute), `null` when an explicit `Path` attribute is present. Adding `!cookie.pathIsDefault` to the condition rejects the attribute-less cookie while leaving an explicit `Path=/` accepted.

## Tests

Added two cases to `lib/__tests__/cookiePrefixes.spec.ts` under `strict` / `__Host prefix`: an attribute-less cookie now rejects, an explicit `Path=/` cookie still works. The first fails on `master` and passes with this change. Full suite is green (784 tests).
