### PR TITLE
Fix documentation typos

### DIFF
--- a/api/docs/tough-cookie.createcookiejaroptions.allowsecureonlocal.md
+++ b/api/docs/tough-cookie.createcookiejaroptions.allowsecureonlocal.md
@@ -4,9 +4,9 @@
 
 ## CreateCookieJarOptions.allowSecureOnLocal property
 
-Flag to indicate if localhost and loopback addresses with an unsecure scheme should store and retrieve `Secure` cookies.
+Flag to indicate if localhost and loopback addresses with an insecure scheme should store and retrieve `Secure` cookies.
 
-If `true`<!-- -->, localhost, loopback addresses or similarly local addresses are treated as secure contexts and thus will store and retrieve `Secure` cookies even with an unsecure scheme.
+If `true`<!-- -->, localhost, loopback addresses or similarly local addresses are treated as secure contexts and thus will store and retrieve `Secure` cookies even with an insecure scheme.
 
 If `false`<!-- -->, only secure schemes (`https` and `wss`<!-- -->) will store and retrieve `Secure` cookies.
 

--- a/api/docs/tough-cookie.createcookiejaroptions.md
+++ b/api/docs/tough-cookie.createcookiejaroptions.md
@@ -50,9 +50,9 @@ boolean \| undefined
 
 </td><td>
 
-_(Optional)_ Flag to indicate if localhost and loopback addresses with an unsecure scheme should store and retrieve `Secure` cookies.
+_(Optional)_ Flag to indicate if localhost and loopback addresses with an insecure scheme should store and retrieve `Secure` cookies.
 
-If `true`<!-- -->, localhost, loopback addresses or similarly local addresses are treated as secure contexts and thus will store and retrieve `Secure` cookies even with an unsecure scheme.
+If `true`<!-- -->, localhost, loopback addresses or similarly local addresses are treated as secure contexts and thus will store and retrieve `Secure` cookies even with an insecure scheme.
 
 If `false`<!-- -->, only secure schemes (`https` and `wss`<!-- -->) will store and retrieve `Secure` cookies.
 

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -185,10 +185,10 @@ export interface CreateCookieJarOptions {
    */
   allowSpecialUseDomain?: boolean | undefined
   /**
-   * Flag to indicate if localhost and loopback addresses with an unsecure scheme should store and retrieve `Secure` cookies.
+   * Flag to indicate if localhost and loopback addresses with an insecure scheme should store and retrieve `Secure` cookies.
    *
    * If `true`, localhost, loopback addresses or similarly local addresses are treated as secure contexts
-   * and thus will store and retrieve `Secure` cookies even with an unsecure scheme.
+   * and thus will store and retrieve `Secure` cookies even with an insecure scheme.
    *
    * If `false`, only secure schemes (`https` and `wss`) will store and retrieve `Secure` cookies.
    *


### PR DESCRIPTION
## Summary
I fix spelling mistakes in documentation and changelog text.

Changed files:
- `api/docs/tough-cookie.createcookiejaroptions.allowsecureonlocal.md`
- `api/docs/tough-cookie.createcookiejaroptions.md`
- `lib/cookie/cookieJar.ts`

## Testing
I run `git diff --check`.
