### PR TITLE
fix: avoid decoding URL authority part

### DIFF
--- a/lib/__tests__/regression.spec.ts
+++ b/lib/__tests__/regression.spec.ts
@@ -33,6 +33,25 @@ describe('Regression Tests', () => {
     )
   })
 
+  it('should not decode authority when getting cookies', async () => {
+    const cookieJar = new CookieJar()
+    await cookieJar.setCookie('a=b; Path=/', 'https://example.com/')
+    const cookieStr = await cookieJar.getCookieString(
+      'https://example.com%5C@example.net/',
+    )
+    expect(cookieStr).toBe('')
+  })
+
+  it('should not decode authority when setting cookies', async () => {
+    const cookieJar = new CookieJar()
+    await cookieJar.setCookie(
+      'a=b; Path=/',
+      'https://example.com%5C@example.net/',
+    )
+    const cookieStr = await cookieJar.getCookieString('https://example.com/')
+    expect(cookieStr).toBe('')
+  })
+
   it('should allow setCookie (without options) callback works even if it is not instanceof Function (GH-158/GH-175)', () => {
     expect.assertions(2)
     const cookieJar = new CookieJar()

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -225,10 +225,19 @@ function getCookieContext(url: unknown): UrlContext {
       protocol: url.protocol,
     }
   } else if (typeof url === 'string') {
+    const parsed = new URL(url)
+    // Decode the path so percent-encoded segments match stored cookie paths
+    // (RFC 6265 §5.4). Only the pathname gets decoded, not the full URI.
+    let pathname = parsed.pathname
     try {
-      return new URL(decodeURI(url))
+      pathname = decodeURI(pathname)
     } catch {
-      return new URL(url)
+      // Malformed percent-encoding in the path; match it verbatim.
+    }
+    return {
+      hostname: parsed.hostname,
+      pathname,
+      protocol: parsed.protocol,
     }
   } else {
     throw new ParameterError('`url` argument is not a string or URL.')


### PR DESCRIPTION
Decoding the URL can result in incorrect parsing in some cases.