### PR TITLE
Replace tldts with tldkit

### DIFF
--- a/lib/getPublicSuffix.ts
+++ b/lib/getPublicSuffix.ts
@@ -1,4 +1,4 @@
-import { getDomain } from 'tldts'
+import { getDomain } from 'tldkit'
 
 // RFC 6761
 const SPECIAL_USE_DOMAINS = ['local', 'example', 'invalid', 'localhost', 'test']

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.0.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "tldts": "^7.0.5"
+        "tldkit": "^1.0.2"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
@@ -5235,23 +5235,14 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tldts": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
-      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+    "node_modules/tldkit": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tldkit/-/tldkit-1.0.2.tgz",
+      "integrity": "sha512-c9reSPdQLmnSFK70NDsEoywHGTxrQ+LobvIHoErf3BoaCDRMvl61+2hIqOXIoUFwwXTFhxlhRvtu48ilz1jqHA==",
       "license": "MIT",
-      "dependencies": {
-        "tldts-core": "^7.4.5"
-      },
-      "bin": {
-        "tldts": "bin/cli.js"
+      "engines": {
+        "node": ">=16"
       }
-    },
-    "node_modules/tldts-core": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
-      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
-      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -143,6 +143,6 @@
     "vitest": "^4.0.7"
   },
   "dependencies": {
-    "tldts": "^7.0.5"
+    "tldkit": "^1.0.2"
   }
 }


### PR DESCRIPTION
Closes #624.

Swaps the one runtime dependency, `tldts`, for `tldkit`. The only source change is the import in `lib/getPublicSuffix.ts`. `tldkit` exports `getDomain` with the same signature and defaults, so the call site is unchanged.

The reason is install size. `tldts` plus `tldts-core` is 3,186.9 KB installed, nearly all of tough-cookie's 3,929 KB tree. `tldkit` is 140.9 KB. About 1,809 KB of the `tldts` tree is sourcemaps, and the suffix trie ships several times over. Heap with the list resident goes from 1,140 KB to 645 KB, which matters for test runners that fork per file. Warm throughput is the same, but `tldkit` expands its packed dataset on first lookup rather than at module load, so the first call costs 0.77 ms against 0.33 ms.

`tldkit` is MIT, has no runtime dependencies, ships ESM and CJS with types for both, Node 16+, and commits its dataset so install hits no network. It scores 76/78 on the publicsuffix.org conformance suite, the same two failures as `tldts`, and matches it across 105,146 generated cases under both `allowPrivateDomains` settings.

One caveat, also in the issue. The two disagree on 21 hostnames, from 7 PSL wildcard rules that have a deeper wildcard sibling, such as `*.run.app` and `*.mtls.run.app`. For `mtls.run.app` itself, `tldkit` returns no registrable domain and `tldts` returns `run.app`, so `Domain=mtls.run.app` is rejected as a public suffix under `tldkit` and accepted under `tldts`. Subdomains of those hosts agree. `tldkit` follows the publicsuffix.org algorithm here. The others sit under `customer-oci.com`, `snowflake.app`, `firenet.ch`, `futurecms.at` and `cloud.int.apple`. Not reported upstream.

`npm test` passes locally (784 tests), as do lint, format, `attw --pack` and `api-extractor`.

https://github.com/Damin3927/tldkit