### PR TITLE
fix: accept IPv4 Domain attributes instead of treating them as public suffixes

### DIFF
--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -366,6 +366,26 @@ describe('CookieJar', () => {
       expect(cookie?.TTL()).toBe(Infinity)
       expect(cookie?.isPersistent()).toBe(false)
     })
+
+    it.each([
+      { testCase: 'loopback', IPv4: '127.0.0.1' },
+      { testCase: 'public', IPv4: '8.8.8.8' },
+    ])('should store a $testCase IPv4', async (test) => {
+      const t0 = new Date()
+      cookie = await cookieJar.setCookie(
+        `a=b; Domain=${test.IPv4}; Path=/`,
+        `http://${test.IPv4}/`,
+      )
+      expect(cookie).toEqual(
+        expect.objectContaining({
+          creation: t0,
+          lastAccessed: t0,
+          domain: test.IPv4,
+        }),
+      )
+      expect(cookie?.TTL()).toBe(Infinity)
+      expect(cookie?.isPersistent()).toBe(false)
+    })
   })
 
   describe('getCookies', () => {

--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -1300,6 +1300,21 @@ it('should allow cookies with the same name under different domains and/or paths
 })
 
 describe('setCookie errors', () => {
+  it('should allow and retrieve a cookie set with an explicit IPv4 Domain attribute', async () => {
+    const cookieJar = new CookieJar()
+    const cookie = await cookieJar.setCookie(
+      'foo=bar; Domain=127.0.0.1; Path=/',
+      'http://127.0.0.1/',
+    )
+    expect(cookie).toBeDefined()
+    expect(cookie.domain).toBe('127.0.0.1')
+    const cookies = await cookieJar.getCookies('http://127.0.0.1/')
+    expect(cookies).toHaveLength(1)
+    expect(cookies[0]?.key).toBe('foo')
+    expect(cookies[0]?.value).toBe('bar')
+    expect(cookies[0]?.domain).toBe('127.0.0.1')
+  })
+
   it('should throw an error if domain is set to a public suffix', async () => {
     const cookieJar = new CookieJar()
     await expect(

--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -386,6 +386,30 @@ describe('CookieJar', () => {
       expect(cookie?.TTL()).toBe(Infinity)
       expect(cookie?.isPersistent()).toBe(false)
     })
+
+    // Round-trip: an explicit IPv4 Domain must be retrievable, not merely
+    // storable. Before the fix in this PR the cookie was rejected at set time,
+    // so there was nothing to retrieve.
+    it.each([
+      { testCase: 'loopback', IPv4: '127.0.0.1' },
+      { testCase: 'public', IPv4: '8.8.8.8' },
+    ])(
+      'should retrieve a cookie set with an explicit $testCase IPv4 Domain',
+      async (test) => {
+        await cookieJar.setCookie(
+          `a=b; Domain=${test.IPv4}; Path=/`,
+          `http://${test.IPv4}/`,
+        )
+        const cookies = await cookieJar.getCookies(`http://${test.IPv4}/`)
+        expect(cookies).toEqual([
+          expect.objectContaining({
+            key: 'a',
+            value: 'b',
+            domain: test.IPv4,
+          }),
+        ])
+      },
+    )
   })
 
   describe('getCookies', () => {

--- a/lib/__tests__/cookieJar.spec.ts
+++ b/lib/__tests__/cookieJar.spec.ts
@@ -1331,7 +1331,7 @@ describe('setCookie errors', () => {
       'http://127.0.0.1/',
     )
     expect(cookie).toBeDefined()
-    expect(cookie.domain).toBe('127.0.0.1')
+    expect(cookie?.domain).toBe('127.0.0.1')
     const cookies = await cookieJar.getCookies('http://127.0.0.1/')
     expect(cookies).toHaveLength(1)
     expect(cookies[0]?.key).toBe('foo')

--- a/lib/__tests__/parse.spec.ts
+++ b/lib/__tests__/parse.spec.ts
@@ -192,6 +192,16 @@ describe('Cookie.parse', () => {
       },
       assertValidateReturns: true,
     },
+    // IPv6 literal is not a public suffix
+    {
+      input: 'a=b; domain=[::1]',
+      output: {
+        key: 'a',
+        value: 'b',
+        domain: '[::1]',
+      },
+      assertValidateReturns: true,
+    },
     // public suffix foonet.net - top level
     {
       input: 'a=b; domain=foonet.net',

--- a/lib/__tests__/parse.spec.ts
+++ b/lib/__tests__/parse.spec.ts
@@ -182,6 +182,16 @@ describe('Cookie.parse', () => {
       },
       assertValidateReturns: false,
     },
+    // IPv4 literal is not a public suffix
+    {
+      input: 'a=b; domain=127.0.0.1',
+      output: {
+        key: 'a',
+        value: 'b',
+        domain: '127.0.0.1',
+      },
+      assertValidateReturns: true,
+    },
     // public suffix foonet.net - top level
     {
       input: 'a=b; domain=foonet.net',

--- a/lib/cookie/cookie.ts
+++ b/lib/cookie/cookie.ts
@@ -35,7 +35,11 @@ import { inOperator } from '../utils.js'
 import { formatDate } from './formatDate.js'
 import { parseDate } from './parseDate.js'
 import { canonicalDomain } from './canonicalDomain.js'
-import type { SerializedCookie } from './constants.js'
+import {
+  IP_V4_REGEX_OBJECT,
+  IP_V6_REGEX_OBJECT,
+  type SerializedCookie,
+} from './constants.js'
 
 // From RFC6265 S4.1.1
 // note that it excludes \x3B ";"
@@ -682,7 +686,11 @@ export class Cookie {
         return false // S4.1.2.3 suggests that this is bad. domainMatch() tests confirm this
       }
       const suffix = getPublicSuffix(cdomain)
-      if (suffix == null) {
+      if (
+        suffix == null &&
+        !IP_V4_REGEX_OBJECT.test(cdomain) &&
+        !IP_V6_REGEX_OBJECT.test(cdomain)
+      ) {
         // it's a public suffix
         return false
       }

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -568,8 +568,8 @@ export class CookieJar {
             : null
         if (
           suffix == null &&
-          !IP_V4_REGEX_OBJECT.test(cookie.domain) &&
-          !IP_V6_REGEX_OBJECT.test(cookie.domain)
+          !IP_V4_REGEX_OBJECT.test(cdomain ?? '') &&
+          !IP_V6_REGEX_OBJECT.test(cdomain ?? '')
         ) {
           // e.g. "com"
           const err = new Error('Cookie has domain set to a public suffix')

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils.js'
 import { canonicalDomain } from './canonicalDomain.js'
 import {
+  IP_V4_REGEX_OBJECT,
   IP_V6_REGEX_OBJECT,
   PrefixSecurityEnum,
   SerializedCookieJar,
@@ -565,7 +566,11 @@ export class CookieJar {
                 ignoreError: options?.ignoreError,
               })
             : null
-        if (suffix == null && !IP_V6_REGEX_OBJECT.test(cookie.domain)) {
+        if (
+          suffix == null &&
+          !IP_V4_REGEX_OBJECT.test(cookie.domain) &&
+          !IP_V6_REGEX_OBJECT.test(cookie.domain)
+        ) {
           // e.g. "com"
           const err = new Error('Cookie has domain set to a public suffix')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,9 +1057,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1077,9 +1074,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,9 +1091,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1117,9 +1108,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,9 +1125,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1157,9 +1142,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4071,9 +4053,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4095,9 +4074,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4119,9 +4095,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4143,9 +4116,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,6 +1057,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1074,6 +1077,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1091,6 +1097,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1108,6 +1117,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1125,6 +1137,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1142,6 +1157,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4053,6 +4071,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4074,6 +4095,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4095,6 +4119,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4116,6 +4143,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## What

`CookieJar.setCookie` rejects a cookie whose `Domain` is an IPv4 literal with `Cookie has domain set to a public suffix`. An IP address is not a public suffix. The IPv6 form of the same address is already accepted.

Fixes #626.

## Why

`getPublicSuffix()` (via tldts) returns nothing for `127.0.0.1`. The public-suffix guard in `setCookie` already skips that failure for IPv6 (`IP_V6_REGEX_OBJECT`) but not for IPv4, so:

```js
await jar.setCookie('a=b; Domain=127.0.0.1', 'http://127.0.0.1/')
// Error: Cookie has domain set to a public suffix

await jar.setCookie('a=b; Domain=[::1]', 'http://[::1]/')
// ok
```

Host-only cookies on `http://127.0.0.1/` already work; only an explicit `Domain=` attribute was broken.

## How

Use the existing `IP_V4_REGEX_OBJECT` next to the IPv6 check in `CookieJar.setCookie` and in `Cookie.validate()`, so an IPv4 literal is treated as a host, not a registry suffix. Real public suffixes such as `kyoto.jp` are still rejected.

## Testing

```
npx vitest run
```

787 tests passed, including new cases for `Domain=127.0.0.1` / `Domain=8.8.8.8` on `setCookie` and `Cookie.validate()`.


Made with [Cursor](https://cursor.com)