### PR TITLE
fix: decode request path for URL object inputs, matching string inputs

### DIFF
--- a/lib/__tests__/regression.spec.ts
+++ b/lib/__tests__/regression.spec.ts
@@ -52,6 +52,19 @@ describe('Regression Tests', () => {
     expect(cookieStr).toBe('')
   })
 
+  it('should decode the request path consistently for string and URL object inputs', async () => {
+    const cookieJar = new CookieJar()
+    await cookieJar.setCookie('a=b; Path=/foo bar', 'https://example.com/')
+    const viaString = await cookieJar.getCookieString(
+      'https://example.com/foo%20bar/baz',
+    )
+    const viaUrl = await cookieJar.getCookieString(
+      new URL('https://example.com/foo%20bar/baz'),
+    )
+    expect(viaString).toBe('a=b')
+    expect(viaUrl).toBe(viaString)
+  })
+
   it('should allow setCookie (without options) callback works even if it is not instanceof Function (GH-158/GH-175)', () => {
     expect.assertions(2)
     const cookieJar = new CookieJar()

--- a/lib/cookie/cookieJar.ts
+++ b/lib/cookie/cookieJar.ts
@@ -219,9 +219,17 @@ function getCookieContext(url: unknown): UrlContext {
     'protocol' in url &&
     typeof url.protocol === 'string'
   ) {
+    // Decode the path so percent-encoded segments match stored cookie paths
+    // (RFC 6265 §5.4), consistent with the string branch below.
+    let pathname = url.pathname
+    try {
+      pathname = decodeURI(pathname)
+    } catch {
+      // Malformed percent-encoding in the path; match it verbatim.
+    }
     return {
       hostname: url.hostname,
-      pathname: url.pathname,
+      pathname,
       protocol: url.protocol,
     }
   } else if (typeof url === 'string') {


### PR DESCRIPTION
`getCookieContext()` decodes the request pathname (`decodeURI`) when the URL is passed as a string, but returns `url.pathname` verbatim when a `URL` object is passed. Since both `setCookie` and `getCookies` accept `string | URL`, the two forms behave differently for percent-encoded paths: a cookie set at `Path=/foo bar` is returned for the string `https://example.com/foo%20bar/baz` but not for the equivalent `new URL(...)`.

This applies the same pathname-only decode (RFC 6265 §5.4) to the URL-object branch. The authority is still never decoded, so the #614 regression tests are unaffected. Adds a regression test asserting string and `URL` inputs return identical cookies.
