### PR TITLE
Fix Max-Age serializing as the literal word Infinity/-Infinity

### DIFF
--- a/lib/__tests__/cookieToString.spec.ts
+++ b/lib/__tests__/cookieToString.spec.ts
@@ -51,4 +51,17 @@ describe('Cookie.toString()', () => {
     })
     expect(cookie.toString()).toBe('a=b; Expires=Fri, 10 Sep 2010 10:10:10 GMT')
   })
+
+  it('should omit Max-Age entirely when it has been set to Infinity', () => {
+    const cookie = new Cookie({ key: 'a', value: 'b' })
+    cookie.setMaxAge(Infinity)
+    expect(cookie.toString()).toBe('a=b')
+  })
+
+  it('should output a real Max-Age, not the word "-Infinity", for a cookie set to expire immediately', () => {
+    const cookie = new Cookie({ key: 'a', value: 'b' })
+    cookie.setMaxAge(-Infinity)
+    expect(cookie.maxAge).toBe('-Infinity')
+    expect(cookie.toString()).toBe('a=b; Max-Age=0')
+  })
 })

--- a/lib/cookie/cookie.ts
+++ b/lib/cookie/cookie.ts
@@ -750,8 +750,11 @@ export class Cookie {
       }
     }
 
-    if (this.maxAge != null && this.maxAge != Infinity) {
-      str += `; Max-Age=${String(this.maxAge)}`
+    if (this.maxAge != null && this.maxAge !== 'Infinity') {
+      // "-Infinity" isn't a valid Max-Age token per RFC6265 (delta-seconds is a
+      // plain signed integer), so a cookie that's been set to expire
+      // immediately gets a real number instead of the literal word.
+      str += `; Max-Age=${this.maxAge === '-Infinity' ? '0' : String(this.maxAge)}`
     }
 
     if (this.domain && !this.hostOnly) {


### PR DESCRIPTION
`setMaxAge()` accepts `Infinity` and `-Infinity` and stores them as the strings `'Infinity'` / `'-Infinity'` on the cookie (there's a comment explaining this is so the value survives a JSON round trip, since actual `Infinity` doesn't serialize). `toString()` was supposed to skip the Max-Age attribute for both of those, same as it does for `expires: 'Infinity'`, but it only actually does that for the positive case:

```js
const c = new Cookie({ key: 'a', value: 'b' })
c.setMaxAge(-Infinity)
c.toString() // 'a=b; Max-Age=-Infinity'
```

The reason is a loose-equality accident: the check was `this.maxAge != Infinity`, and in JS `'Infinity' == Infinity` is true (string gets coerced to a number) while `'-Infinity' == Infinity` is false, so the negative case slipped through to the serialization branch untouched.

`Max-Age=-Infinity` isn't something any real HTTP client can parse — RFC 6265's delta-seconds is a plain signed integer, no word tokens. A cookie in this state represents "expire right now," so the fix emits `Max-Age=0` instead, which is the normal, widely understood way to tell a client to drop a cookie immediately.

Also switched the Infinity check itself to a strict string comparison rather than relying on the `==` coercion, since that's what was masking the bug.

Added two tests to `cookieToString.spec.ts` covering both the Infinity (still omitted) and -Infinity (now `Max-Age=0`) cases. Ran the full suite (786 tests) and lint, both clean.
